### PR TITLE
Bdant/tokens redux part deux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,170 @@
 # xblock-launchcontainer
 Open edX XBlock to include Appsembler's external course Container launcher
 
-# Installation
+v Installation
+
+## FOR LOCAL DEVELOPMENT
+
+*The easiest way to do local development is with the `xblock-sdk`.* 
+
+### Step 1: Get the xblock-sdk
+
+``` 
+git clone git@github.com:edx/xblock-sdk.git
 ```
-$ pip install -e git+https://github.com/jazkarta/xblock-launchcontainer.git@master#egg=launchcontainer
+
+### Step 2: Set up a virtualenv (not virtualenvwrapper)
+
+*Virtualenvwrapper doesn't allow the editable install process to work properly.* 
+
 ```
+cd xblock-sdk
+virtualenv .
+```
+
+### Step 3: Install this package in "editable mode"
+
+Append this package to your `xblock-sdk/requirements/base.txt`:
+
+``` 
+-e git+https://github.com/appsembler/xblock-launchcontainer.git@master#egg=launchcontainer
+```
+
+Install the packages:
+
+*Note: This command is more complex than necessary due to a bug in pip--but this is what we need to make it work.*
+
+``` 
+$ PYTHONPATH=$(pwd)/lib/python2.7/site-packages pip install --install-option="--prefix=$(pwd)" -r requirements/base.txt
+```
+
+### Step 4: Start the xblock-sdk server 
+
+``` 
+python manage.py migrate
+python manage.py runserver 8002  # Use 8002 b/c devstack will take 8000 and 8001
+```
+
+You should now see a "Single Launchcontainer" in the list of avaialable XBlocks:
+
+*TODO: Add LC screenshot*
+
+### Step 5: Set up the Wharf machine and configure the XBlock to talk to it
+
+To make a request from the XBlock to Wharf, you should set up your local Wharf environment (instructions [here](https://github.com/appsembler/wharf/blob/develop/docs/index.md)). Then take the ip of the container running Wharf master server, and set environment variables that will tell the XBlock where to make the request. First, modify your `xblock-sdk/workbench/settings.py` to include this: 
+
+``` 
+ENV_TOKENS = {
+    'LAUNCHCONTAINER_API_CONF': {
+     'http://192.xxx.xx.xxx:8000/path/to/AVLContainerEndpoint/'
+    }
+}
+```
+
+*1. HOST should be the IP of the machine hosting your Wharf containers.*
+*2. The PATH should be the path of the endpoint in Wharf that receives requests to deploy new containers.*
+
+Start Django's dev server:
+
+``` 
+python manage.py runserver 8002
+```
+
+You should then be able to take the title and the token of a Wharf project, and plug it into the XBlock: 
+
+*To find this view, append studio_view/ to any "scenario" url that the sdk generates.*
+
+*TODO: Insert screenshot of sdk studio_view.*
+
+## INSTALL FOR DEVSTACK DEVELOPMENT 
+
+*Tested with Eucalyptus.*
+
+### Install the launchcontainer source 
+
+If you have devstack installed, you'll find a `src/` directory on your host, where we'll install the xblock: 
+
+``` 
+$ ls
+Vagrantfile         ecommerce           edx-platform        programs            themes
+cs_comments_service ecommerce-worker    lib                 src
+```
+
+To clone the repo using pip in editable mode, we're going to have to use virtualenv (not virtualenvwrapper): 
+
+``` 
+$ cd <devstackDir> 
+$ virtualenv .
+$ pip install --target=$(pwd)/lib/python2.7 -e git+https://github.com/appsembler/xblock-launchcontainer.git@master#egg=launchcontainer
+```
+
+A mirrored copy of the xblock will now be in the Vagrant machine's `/edx/src/` directory. Next you'll set up pip within the devstack to use the proper location: 
+
+```
+$ vagrant ssh 
+$ sudo su edxapp
+$ /edx/bin/pip.edxapp install -e git+https://github.com/appsembler/xblock-launchcontainer.git@master#egg=launchcontainer
+```
+
+Now we'll edit pips recent install to point to your source by updating the `/edx/app/edxapp/venvs/edxapp/lib/python2.7/site-packages/xblock-launchcontainer.egg-link` file to read as follows: 
+
+```
+/edx/src/launchcontainer
+```
+
+Next, you'll need to update the `/edx/app/edxapp/venvs/edxapp/lib/python2.7/site-packages/easy-install.pth` file to include `/edx/src/xblock-launchcontainer` amongst the several other packages listed there: 
+
+```
+...
+/edx/app/edxapp/venvs/edxapp/src/rate-xblock
+/edx/app/edxapp/venvs/edxapp/src/done-xblock
+/edx/app/edxapp/venvs/edxapp/src/xblock-google-drive
+/edx/src/launchcontainer
+/edx/app/edxapp/venvs/edxapp/src/edx-reverification-block
+/edx/app/edxapp/venvs/edxapp/src/edx-sga
+/edx/app/edxapp/venvs/edxapp/src/xblock-poll
+...
+```
+
+### Enable the XBlock in the devstack UI 
+
+In Studio, navigate to a Course > 'Advanced Settings' > 'Advanced Module List' and add `launchcontainer` to the list.
+
+### Set the env vars to point to your instance of Wharf
+
+Update your `lms.env.json` and `cms.env.json` to include:
+
+```
+'LAUNCHCONTAINER_API_CONF': {
+    'http://192.xxx.xx.xxx:8000/path/to/avlContainerEndpoint/'
+}
+```
+
+Then restart your devstack studio, and you should be able to use the XBlock, making requests to your local instance of Wharf.
+
+*WARNING: If you are logged in to Wharf in one tab, trying to make requests from the xblock-sdk web server, you'll likely see a 403, and a message that says you've submitted an incorrect token. This fails just because you have a `sessionid` in the other tab and the Wharf API is taking that and treating you like a staff user, who needs a CSRF token. It is hereby recommended that you use an incognito window for the xblock-sdk server and the edX studio server.*
+
+## PRODUCTION INSTALL 
+
+### Install the master branch of this repo with pip 
+
+```
+$ pip install -e git+https://github.com/appsembler/xblock-launchcontainer.git@master#egg=launchcontainer
+```
+
 or add to your requires.txt
+
 ```
 -e git+https://github.com/jazkarta/xblock-launchcontainer.git@master#egg=launchcontainer
 ```
 
 Update your `lms.env.json` and `cms.env.json` to add:
+
 ```
 "ADDL_INSTALLED_APPS" : ["launchcontainer"]
 ```
 and 
+
 ```
 "FEATURES": {
     "ALLOW_ALL_ADVANCED_COMPONENTS": true
@@ -33,6 +183,3 @@ and
 * Create a Section, Sub-section and Unit, if you haven’t already
 * In the “Add New Component” interface, you should now see an “Advanced” button
 * Click “Advanced” and choose “launchcontainer”
-
-
-

--- a/launchcontainer/launchcontainer.py
+++ b/launchcontainer/launchcontainer.py
@@ -1,4 +1,3 @@
-
 """This XBlock provides an HTML page fragment to display a button
    allowing the Course user to launch an external course Container
    via Appsembler's Container deploy API.
@@ -9,6 +8,7 @@ import logging
 
 from django.conf import settings
 from django.template import Context, Template
+from django.core import validators
 
 from xblock.core import XBlock
 from xblock.fields import Scope, String
@@ -18,48 +18,48 @@ from xblock.fragment import Fragment
 log = logging.getLogger(__name__)
 
 
-try:
-    API_URL_DEFAULT = settings.ENV_TOKENS.get('LAUNCHCONTAINER_API_CONF', None)['default']
-except TypeError:
-    API_URL_DEFAULT = 'http://isc.appsembler.com/isc/newdeploy'  # BBB
+DEFAULT_API_CONF = {'https://wharf.appsembler.com/isc/newdeploy'}
 
 
 class LaunchContainerXBlock(XBlock):
     """
-    Provide a Fragment with associated Javascript to display to 
+    Provide a Fragment with associated Javascript to display to
     Students a button that will launch a configurable external course
     Container via a call to Appsembler's container deploy API.
     """
 
-    display_name = String(help="Display name of the component", 
+    display_name = String(help="Display name of the component",
                           default="Container Launcher",
                           scope=Scope.settings)
 
     project = String(
         display_name='Project name',
-        default=u'(EDIT THIS COMPONENT TO SET PROJECT NAME)', 
+        placeholder=u'Please enter the project id from AVL.',
+        default=u'',
         scope=Scope.content,
-        help=(u"The name of the container's Project as defined for the "
-             "Appsembler API"),
+        help=(u"The name of the project as defined for the "
+              "Appsembler Virtual Labs (AVL) API."),
     )
 
     project_friendly = String(
         display_name='Project Friendly name',
-        default=u'', 
+        default=u'',
         scope=Scope.content,
         help=(u"The name of the container's Project as displayed to the end "
-             "user"),
+              "user"),
     )
 
-    api_url = String(
-        default=API_URL_DEFAULT,
+    project_token = String(
+        display_name='Project Token',
+        default=u'',
         scope=Scope.content,
+        help=(u"This is a unique token that can be found in the AVL dashboard.")
     )
 
     @property
     def block_course_org(self):
         return self.runtime.course_id.org
-    
+
     @property
     def student_email(self):
         if hasattr(self, "runtime"):
@@ -69,11 +69,11 @@ class LaunchContainerXBlock(XBlock):
             return None
 
     def _get_API_url(self):
-        api_conf = settings.ENV_TOKENS.get('LAUNCHCONTAINER_API_CONF', None)
-        try:
-            return api_conf[self.block_course_org]
-        except (TypeError, KeyError):
-            return API_URL_DEFAULT
+        uri = settings.ENV_TOKENS.get('LAUNCHCONTAINER_API_CONF', DEFAULT_API_CONF)
+        url_validator = validators.URLValidator()
+        url_validator(uri)
+
+        return uri
 
     def student_view(self, context=None):
         """
@@ -98,13 +98,15 @@ class LaunchContainerXBlock(XBlock):
         context = {
             'project': self.project,
             'project_friendly': self.project_friendly,
-            'user_email' : user_email,
-            'API_url': self.api_url
+            'project_token': self.project_token,
+            'user_email': user_email,
+            'API_url': self._get_API_url()
         }
         frag = Fragment()
         frag.add_content(
             render_template('static/html/launchcontainer.html', context)
         )
+        frag.add_css(render_template("static/css/launchcontainer.css"))
         frag.add_javascript(render_template("static/js/src/launchcontainer.js",
                                             context))
         frag.initialize_js('LaunchContainerXBlock')
@@ -122,16 +124,19 @@ class LaunchContainerXBlock(XBlock):
                 Return empty string if data is None else return data.
                 """
                 return data if data is not None else ''
-           
+
             edit_fields = (
                (field, none_to_empty(getattr(self, field.name)), validator)
                for field, validator in (
-                   (cls.project, 'string'), 
-                   (cls.project_friendly, 'string'), )
+                   (cls.project, 'string'),
+                   (cls.project_friendly, 'string'),
+                   (cls.project_token, 'string'),
+               )
             )
 
             context = {
-                'fields': edit_fields
+                'fields': edit_fields,
+                'API_url': self._get_API_url()
             }
             fragment = Fragment()
             fragment.add_content(
@@ -140,26 +145,36 @@ class LaunchContainerXBlock(XBlock):
                     context
                 )
             )
+            # TODO: Should we be relying more heavily on XBlock's tools for
+            # loading this stuff? See:
+            # http://edx.readthedocs.io/projects/xblock-tutorial/en/latest/concepts/methods.html#view-methods
+            fragment.add_css(render_template("static/css/launchcontainer_edit.css"))
             fragment.add_javascript(
-                load_resource("static/js/src/launchcontainer_edit.js"))
+                load_resource("static/js/src/launchcontainer_edit.js")
+            )
             fragment.initialize_js('LaunchContainerEditBlock')
 
             return fragment
         except:  # pragma: NO COVER
+            # TODO: Handle all the errors and handle them well.
             log.error("Don't swallow my exceptions", exc_info=True)
             raise
 
     @XBlock.json_handler
     def studio_submit(self, data, suffix=''):
         log.info(u'Received data: {}'.format(data))
+
+        # TODO: This could use some better validation.
         try:
-            self.project = data['project']
-            self.project_friendly = data['project_friendly']
+            self.project = data['project'].strip()
+            self.project_friendly = data['project_friendly'].strip()
+            self.project_token = data['project_token'].strip()
             self.api_url = self._get_API_url()
 
             return {
                 'result': 'success',
             }
+
         except Exception as e:
             return {
                 'result': 'Error saving data:{0}'.format(str(e))
@@ -177,12 +192,14 @@ class LaunchContainerXBlock(XBlock):
              """)
         ]
 
+
 def load_resource(resource_path):  # pragma: NO COVER
-     """
-     Gets the content of a resource
-     """
-     resource_content = pkg_resources.resource_string(__name__, resource_path)
-     return unicode(resource_content)
+    """
+    Gets the content of a resource
+    """
+    resource_content = pkg_resources.resource_string(__name__, resource_path)
+
+    return unicode(resource_content)
 
 
 def render_template(template_path, context=None):  # pragma: NO COVER
@@ -194,4 +211,5 @@ def render_template(template_path, context=None):  # pragma: NO COVER
 
     template_str = load_resource(template_path)
     template = Template(template_str)
+
     return template.render(Context(context))

--- a/launchcontainer/static/css/launchcontainer.css
+++ b/launchcontainer/static/css/launchcontainer.css
@@ -1,0 +1,23 @@
+.hide {
+  display: none;
+}
+
+.wraptext {
+  display: block;
+  white-space: normal !important;
+  padding: 5px;
+}
+
+div#launcher_notification {
+  padding: 10px;
+  margin: 10px 0;
+  display: inline-block;
+}
+
+div#launcher_notification p {
+  margin-bottom: 0;
+}
+
+#launcher_submit {
+  padding: 10px;
+}

--- a/launchcontainer/static/css/launchcontainer_edit.css
+++ b/launchcontainer/static/css/launchcontainer_edit.css
@@ -1,0 +1,3 @@
+[class*="view-"] .modal-window .editor-with-buttons {
+  margin-bottom: 0;
+}

--- a/launchcontainer/static/html/launchcontainer.html
+++ b/launchcontainer/static/html/launchcontainer.html
@@ -1,6 +1,10 @@
 <div id="launcher1">
-    <iframe src="{{ API_url }}" style="visibility: hidden" width="0" height="0"></iframe>
-    <p>When you click the button below, a new {{ project_friendly }} site will be started for you.</p>
-    <input type="button" value="Launch {{ project_friendly }} site" style="margin-bottom: 20px;" />
+  <iframe src="{{ API_url }}" style="visibility: hidden" width="0" height="0"></iframe>
+  <form id="launcher_form">
+    <input type="text" class="hide" id="launcher_email" name="owner_email" {% if user_email %}value="{{ user_email }}"{% endif %} placeholder="Please enter your email address" />
+    <input type="text" class="hide" id="launcher_token" name="token" value="{{ project_token }}" />
+    <input type="text" class="hide" id="launcher_project" name="project" value="{{ project }}" />
+    <button type="submit" class="ui-priority-primary" id="launcher_submit">Click to launch your {{ project_friendly }} lab</button>
+  </form>
+  <div id="launcher_notification" class="hide"></div>
 </div>
-

--- a/launchcontainer/static/html/launchcontainer_edit.html
+++ b/launchcontainer/static/html/launchcontainer_edit.html
@@ -1,21 +1,25 @@
 {% load i18n %}
 <div class="wrapper-comp-settings is-active editor-with-buttons" id="settings-tab">
-  <div class="ui-state-error" id="error-message"></div>
 
-  <ul class="list-input settings-list" style="height: auto">
-    {% for field, value, validator in fields %}
-    <li class="field comp-setting-entry metadata_entry is-set">
-      <div class="wrapper-comp-setting">
-        <label class="label setting-label" 
-          for="{{ field.name }}_input">{{ field.display_name }}</label>
-        <input class="input setting-input" type="text" 
-               id="{{ field.name }}_input" name="{{ field.name}}" 
-               value="{{ value }}" data-validator="{{ validator }}"/>
-      </div>
-      <span class="tip setting-help">{{ field.help }}</span>
-    </li>
-    {% endfor %}
-  </ul>
+  <form id="#launch-container-edit-form">
+    <ul class="list-input settings-list" style="height: auto">
+      {% for field, value, validator in fields %}
+      <li class="field comp-setting-entry metadata_entry is-set">
+        <div class="wrapper-comp-setting">
+          <label class="label setting-label" 
+                 for="{{ field.name }}_input">{{ field.display_name }}</label>
+          <input class="input setting-input" type="text" id="{{ field.name }}_input" name="{{ field.name }}" 
+                 value="{{ value }}" data-validator="{{ validator }}" >
+        </div>
+        <span class="tip setting-help">{{ field.help }}</span>
+      </li>
+      {% endfor %}
+      <li class="field comp-setting-entry metadata_entry">
+        <span class="tip setting-help">
+          Should it prove useful for debugging purposes, the endpoint that this project will post to is <code>{{ API_url }}</code>.
+        </span>
+      </li>
+    </ul>
 </div>
 <div class="xblock-actions">
   <ul>
@@ -25,5 +29,9 @@
     <li class="action-item">
       <a href="#" class="button cancel-button">Cancel</a>
     </li>
+    <li id="notification-message" class="field comp-setting-entry metadata_entry hide">
+      <span class="tip setting-help"> </span>
+    </li>
   </ul>
+  <form>
 </div>

--- a/launchcontainer/static/js/src/launchcontainer.js
+++ b/launchcontainer/static/js/src/launchcontainer.js
@@ -1,33 +1,76 @@
 function getURLOrigin(path) {
-    var link = document.createElement('a');
-    link.setAttribute('href', path);
+  var link = document.createElement('a');
+  link.setAttribute('href', path);
 
-    port = (link.port) ? ':'+link.port : '';
-    return link.protocol + '//' + link.hostname + port;
+  port = (link.port) ? ':'+link.port : '';
+  return link.protocol + '//' + link.hostname + port;
 }
 
 function LaunchContainerXBlock(runtime, element) {
 
-    $(document).ready(
-      function () {
-        var $launcher = $('#launcher1'), $launch_button = $launcher.find('input');
-        $launch_button.click(function() {
-            console.log('Clicked launch button');
-            $launch_button.attr('disabled', 'disabled').val('Launching...');
-            $launcher.find('iframe')[0].contentWindow.postMessage({
-                owner_email: "{{ user_email }}",
-                project: "{{ project }}"
-            }, "{{ API_url }}");
-            return false;
-        });
-        window.addEventListener("message", function (event) {
-            if (event.origin !== getURLOrigin('{{ API_url }}')) return;
-            if(event.data.status === 'siteDeployed') {
-                $launcher.html(event.data.html_content);
-            } else if(event.data.status === 'deploymentError') {
-                $launcher.text(event.data.error_message);
-            }
-        }, false);
-    });
+  $(document).ready(
+    function () {
+      // Submit the data to the AVL server and process the response. //
+      var $launcher = $('#launcher1'),
+          $post_url = '{{ API_url|escapejs }}',
+          $launcher_form = $('#launcher_form'),
+          $launcher_submit = $('#launcher_submit'),
+          $launcher_email = $('#launcher_email'),
+          $launch_notification = $('#launcher_notification'), 
+          $waiting = 'Your request for a lab is being processed, and may take up to 90 seconds to start. '
+          + 'If you are having issues, please <a href="mailto:technical@appsembler.com">notify us</a>.'
 
+      // This is for studio: If there is no email addy, 
+      // you can enter it manually.
+      if (!$launcher_email.val()) {
+        $launcher_email.removeClass('hide');
+      }
+
+      $('#launcher_form').submit(function (event) {
+
+        // Shut down the buttons.
+        event.preventDefault();
+        $launcher_submit.disabled = true; 
+        $launcher_submit.val('Launching ...');
+        $launch_notification.html($waiting);
+        $launch_notification.removeClass('hide')
+                            .removeClass('ui-state-error')
+                            .removeClass('ui-state-notification');
+        $launcher.find('iframe')[0].contentWindow.postMessage($(this).serialize(), "{{ API_url|escapejs }}");
+        return false;
+      });
+
+      window.addEventListener("message", function (event) {
+        if (event.origin !== getURLOrigin('{{ API_url|escapejs }}')) return;
+        if(event.data.status === 'siteDeployed') {
+          $launch_notification.removeClass('hide')
+                              .removeClass('ui-state-error')
+                              .html(event.data.html_content);
+          $launcher_form.addClass('hide');
+        } else if(event.data.status === 'deploymentError') {
+          var $status_code = event.data.status_code;
+          var $msg;
+          if ($status_code === 400) {
+            var $errors = event.data.errors;
+            for (i=0; i<$errors.length; i++) { 
+              # TODO: Make this error display better.
+              $msg = $errors[i][0] + ": " + $errors[i][1][0] + " "; 
+            }
+          } else if ($status_code === 403) {
+            $msg = "Your request failed because the token sent with "
+                        +"your request is invalid. "
+          } else if ($status_code === 404) {
+            $msg = "That project was not found. "; 
+          } else if ($status_code === 503) {
+            $msg = event.data.errors + " ";
+          }
+          var $final_msg = "<p class='error'>An error occured in your request: " + $msg + "</p>" 
+                           + "<p> Please contact "
+                           +"<a href=mailto:technical@appsembler.com>the "
+                           +"administrator.</p>";
+          $launch_notification.html($final_msg);
+          $launch_notification.addClass('ui-state-error').removeClass('hide');
+        }
+      }, false);
+    });
 }

--- a/launchcontainer/static/js/src/launchcontainer_edit.js
+++ b/launchcontainer/static/js/src/launchcontainer_edit.js
@@ -1,25 +1,51 @@
 function LaunchContainerEditBlock(runtime, element) {
+
     console.log($('.xblock-save-button', element));
+
+    function notify(response) {
+        var $notificationEl = $('#notification-message'); 
+        var $editModal = $('.wrapper.wrapper-modal-window.wrapper-modal-window-edit-xblock');
+        var $editModalOverlay = $('.modal-window-overlay');
+        var $displayHeader = $('.xblock-header.xblock-header-launchcontainer .header-details');
+        var $editSuccessContent = "Your changes have been successfully applied. "
+                                  + "Please refresh and then click the button above to test.";
+        var $launcherNotification = $('#launcher_notification');
+
+        if (response.result === 'success') {
+          // class="ui-loading is-hidden"
+          
+          // Hide the modal in the Studio interface.
+//          $notificationEl.find('span').html('Your request was successful.');
+          $editModal.addClass('is-hidden');
+          $editModalOverlay.addClass('is-hidden');
+          $launcherNotification.text($editSuccessContent);
+          $launcherNotification.addClass('ui-state-highlight')
+                               .removeClass('ui-state-error')
+                               .removeClass('hide');
+          $('#launcher_form').removeClass('hide');
+        }
+        else {
+          $notificationEl.addClass('error').removeClass('hide').removeClass('is-hidden');
+          $notificationEl.html("It didn't work! "+response.result); 
+        }
+    }
+
     $('.save-button', element).bind('click', function() {
         var handlerUrl = runtime.handlerUrl(element, 'studio_submit');
         var data = {
-            'project': $('input[name=project]').val(),
-            'project_friendly': $('input[name=project_friendly]').val(),
+            'project': $('#project_input').val(),
+            'project_friendly': $('#project_friendly_input').val(),
+            'project_token': $('#project_token_input').val(),
         };
-        runtime.notify('save', {state: 'start'});
-        $.post(handlerUrl, JSON.stringify(data)).done(function(response) {
-            if (response.result === 'success') {
-                runtime.notify('save', {state: 'end'});
-            }
-            else {
-                runtime.notify('save', {state: 'end'});
-                $('#error-message', element).html('Error: '+response.result);
-            }
+
+        $.post(handlerUrl, data)
+          .done(function(response) { 
+              notify(response);
         });
     });
 
     $('.cancel-button', element).bind('click', function() {
-        runtime.notify('cancel', {});
+//        runtime.notify('cancel', {});
     });
 }
 


### PR DESCRIPTION
Okay, this allows the XBlock to submit a token to Wharf, and handle all errors properly. @tomaszzielinski: This JavaScript and some of that validation stuff that I left in the python file is gross. Let's try to discern what needs to be changed now, and what can wait, using the [next card](https://trello.com/c/uiYpMikA/1027-12-xblock-improvements-code-refactor) that I have lined up for a code refactor. 

We'll have to think about the release strategy for this + Wharf's token changes (PR coming shortly). I _think_ we can just set the "grandfathered" var on that side, and we can deploy this freely, but please help me think through that.