### PR TITLE
Rely on a SiteConfiguration for the Wharf endpoint

### DIFF
--- a/launchcontainer/launchcontainer.py
+++ b/launchcontainer/launchcontainer.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.template import Context, Template
 from django.core import validators
 
-from microsite_configuration.models import Microsite
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from xblock.core import XBlock
 from xblock.fields import Scope, String
 from xblock.fragment import Fragment
@@ -89,29 +89,15 @@ class LaunchContainerXBlock(XBlock):
 
         DEFAULT_API_CONF = 'https://wharf.appsembler.com/isc/newdeploy/'
 
-        api_conf = {}
+        # This will first check the SiteConfiguration object that is associated with the Site
+        # object. If that does not exist, it will attempt to fall back to the values in the
+        # MicroSite configuration object.
+        wharf_endpoint = configuration_helpers.get_value(
+            'LAUNCHCONTAINER_API_CONF',
+            settings.ENV_TOKENS.get('LAUNCHCONTAINER_API_CONF', DEFAULT_API_CONF)
+        )
 
-        # Use the microsite value if it is available.
-        if hasattr(self, "runtime"):
-            # TODO: We should really be validating this as the JSON is submitted
-            # in the admin. Let's look into that soon.
-            organization = self.runtime.course_id.org
-            microsite_query = Microsite.objects.filter(key=organization)
-
-            if microsite_query.exists():
-                api_conf = self._validate_conf(
-                    microsite_query[0].values.get('LAUNCHCONTAINER_API_CONF')
-                )
-
-        # If not, fallback to the old way, then all the way back to the default
-        # defined here.
-        if not api_conf:
-            api_conf = self._validate_conf(
-                settings.ENV_TOKENS.get(
-                    'LAUNCHCONTAINER_API_CONF', {}).get('default', DEFAULT_API_CONF)
-            )
-
-        return api_conf
+        return wharf_endpoint
 
     def student_view(self, context=None):
         """


### PR DESCRIPTION
This will allow us to deploy to Tahoe, where the user can modify their microsite vars (via the Django admin) to point to the proper cluster and path. (Really, this is probably going to be Cody or Nate modifying it, not "the user"). 

@tomaszzielinski: Have a go at this one, please. Like the other PR, this does not include the next-level refactor that will clean up some of the things we've discussed. 

This PR is associated with [this card](https://trello.com/c/OG8Ft2rB/1028-8-integrate-microsites-with-xblock). The next round of changes will happen via [this card](https://trello.com/c/uiYpMikA/1027-12-xblock-improvements-code-refactor).

Thanks!
