### PR TITLE
Microsites + get user + tests

### DIFF
--- a/launchcontainer/launchcontainer.py
+++ b/launchcontainer/launchcontainer.py
@@ -110,18 +110,10 @@ class LaunchContainerXBlock(XBlock):
         """
 
         user_email = None
-        # workbench runtime won't supply system property
-        if getattr(self, 'system', None):
-            if self.system.anonymous_student_id:
-                if getattr(self.system, 'get_real_user', None):
-                    anon_id = self.system.anonymous_student_id
-                    user = self.system.get_real_user(anon_id)
-                    if user and user.is_authenticated():
-                        user_email = user.email
-                elif self.system.user_is_staff:  # Studio preview
-                    from django.contrib.auth.models import User
-                    user = User.objects.get(id=self.system.user_id)
-                    user_email = user.email
+
+        user_service = self.runtime.service(self, 'user')
+        user = user_service.get_current_user()
+        user_email = user.emails[0] if type(user.emails) == list else user.email
 
         context = {
             'project': self.project,

--- a/launchcontainer/launchcontainer.py
+++ b/launchcontainer/launchcontainer.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.template import Context, Template
 from django.core import validators
 
-from microsite_configuration.models import Microsite
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from xblock.core import XBlock
 from xblock.fields import Scope, String
 from xblock.fragment import Fragment
@@ -89,29 +89,15 @@ class LaunchContainerXBlock(XBlock):
 
         DEFAULT_API_CONF = 'https://wharf.appsembler.com/isc/newdeploy/'
 
-        api_conf = {}
+        # This will first check the SiteConfiguration object that is associated with the Site
+        # object. If that does not exist, it will attempt to fall back to the values in the
+        # MicroSite configuration object.
+        wharf_endpoint = configuration_helpers.get_value(
+            'LAUNCHCONTAINER_API_CONF',
+            settings.ENV_TOKENS.get('LAUNCHCONTAINER_API_CONF', DEFAULT_API_CONF)
+        )
 
-        # Use the microsite value if it is available.
-        if hasattr(self, "runtime"):
-            # TODO: We should really be validating this as the JSON is submitted
-            # in the admin. Let's look into that soon.
-            organization = self.runtime.course_id.org
-            microsite_query = Microsite.objects.filter(key=organization)
-
-            if microsite_query.exists():
-                api_conf = self._validate_conf(
-                    microsite_query[0].values.get('LAUNCHCONTAINER_API_CONF')
-                )
-
-        # If not, fallback to the old way, then all the way back to the default
-        # defined here.
-        if not api_conf:
-            api_conf = self._validate_conf(
-                settings.ENV_TOKENS.get(
-                    'LAUNCHCONTAINER_API_CONF', {}).get('default', DEFAULT_API_CONF)
-            )
-
-        return api_conf
+        return wharf_endpoint
 
     def student_view(self, context=None):
         """

--- a/launchcontainer/launchcontainer.py
+++ b/launchcontainer/launchcontainer.py
@@ -90,6 +90,7 @@ class LaunchContainerXBlock(XBlock):
     def _get_API_url(self, force=False):
 
         urls = (
+            # TODO: Write tests for each of these.
             # A string: the currently supported implementation.
             settings.ENV_TOKENS.get('LAUNCHCONTAINER_WHARF_ENDPOINT'),
             # A dict: the deprecated version.
@@ -110,7 +111,6 @@ class LaunchContainerXBlock(XBlock):
         """
 
         user_email = None
-
         user_service = self.runtime.service(self, 'user')
         user = user_service.get_current_user()
         user_email = user.emails[0] if type(user.emails) == list else user.email

--- a/launchcontainer/tests.py
+++ b/launchcontainer/tests.py
@@ -8,22 +8,14 @@ import unittest
 from xblock.field_data import DictFieldData
 from opaque_keys.edx.locations import Location, SlashSeparatedCourseKey
 
-from django.test.utils import override_settings
+from django.test import modify_settings
 
-from .launchcontainer import API_URL_DEFAULT
-
-
-API_URL_CONF_SET_WITH_GOOD_ORG = {
-    "org": "https://api.org.com"
-}
+from .launchcontainer import DEFAULT_WHARF_ENDPOINT
 
 
-API_URL_CONF_SET_WITH_BAD_ORG = {
-    "other_org": "https://api.foo.com",
-    "default": "https://api.default.com"
-}
-
-API_URL_CONF_NOT_SET = {}
+WHARF_ENDPOINT_GOOD = "https://api.org.com"
+WHARF_ENDPOINT_BAD = "notARealUrl"
+WHARF_ENDPOINT_UNSET = ""
 
 
 class DummyResource(object):
@@ -72,6 +64,7 @@ class LaunchContainerXBlockTests(unittest.TestCase):
 
         block.project = 'Foo project'
         block.project_friendly = 'Foo Project Friendly Name'
+        block.project_token = 'Foo token'
         return block
 
     @mock.patch('launchcontainer.launchcontainer.load_resource', DummyResource)
@@ -103,26 +96,47 @@ class LaunchContainerXBlockTests(unittest.TestCase):
     def test_studio_view(self, fragment, render_template):
         # pylint: disable=unused-argument
         """
-        Test studio view is displayed correctly.
+        Test that the template, css and javascript are loaded properly into the studio view.
         """
         block = self.make_one()
         fragment = block.studio_view()
-        render_template.assert_called_once()
-        template_arg = render_template.call_args[0][0]
+
+        # Called once for the template, once for the css.
+        self.assertEqual(render_template.call_count, 2)
+
+        # Confirm that the rendered template is the right one.
         self.assertEqual(
-            template_arg,
+            render_template.call_args_list[0][0][0],
             'static/html/launchcontainer_edit.html'
         )
+
+        # Confirm that the context was set properly on the XBlock instance.
         cls = type(block)
-        context = render_template.call_args[0][1]
+        context = render_template.call_args_list[0][0][1]
         self.assertEqual(tuple(context['fields']), (
             (cls.project, 'Foo project', 'string'),
-            (cls.project_friendly, 'Foo Project Friendly Name', 'string')
+            (cls.project_friendly, 'Foo Project Friendly Name', 'string'),
+            (cls.project_token, 'Foo token', 'string')
         ))
+
+        # Confirm that the JavaScript was pulled in.
         fragment.add_javascript.assert_called_once_with(
             DummyResource("static/js/src/launchcontainer_edit.js"))
         fragment.initialize_js.assert_called_once_with(
             "LaunchContainerEditBlock")
+
+        # Confirm that the css was pulled in.
+        fragment.add_css.assert_called_once_with(
+            render_template(
+                DummyResource("static/js/src/launchcontainer_edit.css")
+            )
+        )
+
+        css_template_arg = render_template.call_args_list[1][0][0]
+        self.assertEqual(
+            css_template_arg,
+            'static/css/launchcontainer_edit.css'
+        )
 
     def test_save_launchcontainer(self):
         """
@@ -140,30 +154,35 @@ class LaunchContainerXBlockTests(unittest.TestCase):
             "project_friendly": proj_friendly_str})))
         self.assertEqual(block.display_name, "Container Launcher")
 
-    @override_settings("ENV_TOKENS['LAUNCHCONTAINER_API_CONF']", API_URL_CONF_SET_WITH_GOOD_ORG)
+    @modify_settings(ENV_TOKENS={
+        'LAUNCHCONTAINER_API_CONF': WHARF_ENDPOINT_GOOD
+    })
     def test_api_url_set_defined_with_org(self):
-        """ 
-        Test expected case with ENV TOKEN for API_URL_CONF
+        """
+        Test expected case with ENV TOKEN for DEFAULT_WHARF_ENDPOINT
         """
         block = self.make_one()
         block.studio_submit(mock.Mock(body='{}'))
         self.assertEqual(block.api_url, 'https://api.org.com')
 
-    @override_settings("ENV_TOKENS['LAUNCHCONTAINER_API_CONF']", API_URL_CONF_SET_WITH_BAD_ORG)
+    @modify_settings(ENV_TOKENS={
+        'LAUNCHCONTAINER_API_CONF': WHARF_ENDPOINT_BAD
+    })
     def test_api_url_default_fallback(self):
-        """ 
-        Test expected case with ENV TOKEN for API_URL_CONF
+        """
+        Test expected case with ENV TOKEN for DEFAULT_WHARF_ENDPOINT
         """
         block = self.make_one()
         block.studio_submit(mock.Mock(body='{}'))
         self.assertEqual(block.api_url, 'https://api.default.com')
 
-    @override_settings("ENV_TOKENS['LAUNCHCONTAINER_API_CONF']", API_URL_CONF_NOT_SET)
+    @modify_settings(ENV_TOKENS={
+        'LAUNCHCONTAINER_API_CONF': WHARF_ENDPOINT_UNSET
+    })
     def test_api_url_not_set(self):
-        """ 
-        Test expected case with ENV TOKEN for API_URL_CONF
+        """
+        Test expected case with ENV TOKEN for DEFAULT_WHARF_ENDPOINT
         """
         block = self.make_one()
         block.studio_submit(mock.Mock(body='{}'))
-        self.assertEqual(block.api_url, API_URL_DEFAULT)
-
+        self.assertEqual(block.api_url, DEFAULT_WHARF_ENDPOINT)

--- a/launchcontainer/tests.py
+++ b/launchcontainer/tests.py
@@ -12,7 +12,7 @@ from opaque_keys.edx.locations import Location, SlashSeparatedCourseKey
 
 from django.test import override_settings
 
-from .launchcontainer import DEFAULT_WHARF_ENDPOINT
+from .launchcontainer import DEFAULT_WHARF_URL
 
 
 WHARF_ENDPOINT_GOOD = "https://api.org.com"
@@ -177,39 +177,39 @@ class LaunchContainerXBlockTests(unittest.TestCase):
 
     def test_api_url_set_defined_with_org(self):
         """
-        A valid URL at ENV_TOKENS['LAUNCHCONTAINER_WHARF_ENDPOINT'] should be used as
+        A valid URL at ENV_TOKENS['LAUNCHCONTAINER_WHARF_URL'] should be used as
         the URL for requests.
         """
         ENV_TOKENS = settings.ENV_TOKENS
-        ENV_TOKENS['LAUNCHCONTAINER_WHARF_ENDPOINT'] = WHARF_ENDPOINT_GOOD
+        ENV_TOKENS['LAUNCHCONTAINER_WHARF_URL'] = WHARF_ENDPOINT_GOOD
 
         with override_settings(ENV_TOKENS=ENV_TOKENS):
             block = self.make_one()
-            block._get_API_url()
+            block.wharf_url
             self.assertEqual(block._wharf_endpoint, WHARF_ENDPOINT_GOOD)
 
     def test_api_url_default_fallback(self):
         """
-        If ENV_TOKENS['LAUNCHCONTAINER_WHARF_ENDPOINT'] is empty, the default should
+        If ENV_TOKENS['LAUNCHCONTAINER_WHARF_URL'] is empty, the default should
         be used.
         """
         ENV_TOKENS = settings.ENV_TOKENS
-        ENV_TOKENS['LAUNCHCONTAINER_WHARF_ENDPOINT'] = None
+        ENV_TOKENS['LAUNCHCONTAINER_WHARF_URL'] = None
 
         with override_settings(ENV_TOKENS=ENV_TOKENS):
             block = self.make_one()
-            block._get_API_url()
-            self.assertEqual(block._wharf_endpoint, DEFAULT_WHARF_ENDPOINT)
+            block.wharf_url
+            self.assertEqual(block._wharf_endpoint, DEFAULT_WHARF_URL)
 
     def test_api_url_not_set(self):
         """
-        If ENV_TOKENS['LAUNCHCONTAINER_WHARF_ENDPOINT'] is not a valid url, the default should
+        If ENV_TOKENS['LAUNCHCONTAINER_WHARF_URL'] is not a valid url, the default should
         be used.
         """
         ENV_TOKENS = settings.ENV_TOKENS
-        ENV_TOKENS['LAUNCHCONTAINER_WHARF_ENDPOINT'] = WHARF_ENDPOINT_BAD
+        ENV_TOKENS['LAUNCHCONTAINER_WHARF_URL'] = WHARF_ENDPOINT_BAD
 
         with override_settings(ENV_TOKENS=ENV_TOKENS):
             block = self.make_one()
-            block._get_API_url()
-            self.assertEqual(block._wharf_endpoint, DEFAULT_WHARF_ENDPOINT)
+            block.wharf_url
+            self.assertEqual(block._wharf_endpoint, DEFAULT_WHARF_URL)


### PR DESCRIPTION
- Uses the _proper_ module to get the openedx Site variables.
- Tests have been fixed to work. 
- Changes the way that we get the user from openedx.  
- Changes the name of the wharf url env var. 
- Adds validation to the wharf url. 

- [ ] docs 

I've got a note on my card to edit the README to match these changes.

- [x] tests