### PR TITLE
Merely reload the page instead of using the XBlock runtime

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -223,6 +223,8 @@ ENV_TOKENS["FEATURES"].update({"ALLOW_ALL_ADVANCED_COMPONENTS": true})
 * Click “Advanced” and choose “Container Launcher"
 * Get a project name and token from Wharf, entering them into the appropriate fields 
 
+*The [Open edX documentation on XBlock][xblock-usage] usage may also prove useful at this step.*
+
 ## CONFIGURATION AND VARIABLE PRECEDENCE
 
 You will always have an AVL cluster associated with this XBlock. It can be set in several ways, with the preferred method being the `SiteConfiguration` via the Django sites framework. You can also configure an instance-wide (i.e., across the entire edX instance) by setting an edX environment variable of `LAUNCHCONTAINER_WHARF_URL=http://your.url.com/your/endpoint/`, such that it will be available in `ENV_TOKENS['LAUNCHCONTAINER_WHARF_URL']`. 
@@ -235,3 +237,5 @@ The code will find your URL in the following order:
 4) Fall back to the value defined in `launchcontainer.py`
 
 *Note: This variable is cached, and the cache will be updated when the `SiteConfiguration` is changed.*
+
+[xblock-usage]: http://edx.readthedocs.io/projects/xblock-tutorial/en/latest/edx_platform/devstack.html

--- a/launchcontainer/geckodriver.log
+++ b/launchcontainer/geckodriver.log
@@ -1,0 +1,303 @@
+1498345154986	geckodriver	INFO	Listening on 127.0.0.1:55541
+1498345155995	geckodriver::marionette	INFO	Starting browser /Applications/Firefox.app/Contents/MacOS/firefox-bin with args ["-marionette"]
+1498345157611	Marionette	INFO	Listening on port 55550
+1498345157680	Marionette	WARN	TLS certificate errors will be ignored for this session
+2017-06-24 15:59:17.985 plugin-container[36623:7476832] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9c3b, name = 'com.apple.tsm.portname'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 15:59:17.987 plugin-container[36623:7476832] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9f03, name = 'com.apple.CFPasteboardClient'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+1498345193121	geckodriver	INFO	Listening on 127.0.0.1:55620
+1498345194133	geckodriver::marionette	INFO	Starting browser /Applications/Firefox.app/Contents/MacOS/firefox-bin with args ["-marionette"]
+1498345195709	Marionette	INFO	Listening on port 55629
+1498345195811	Marionette	WARN	TLS certificate errors will be ignored for this session
+2017-06-24 15:59:56.087 plugin-container[36661:7477831] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9c3f, name = 'com.apple.tsm.portname'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 15:59:56.090 plugin-container[36661:7477831] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9f03, name = 'com.apple.CFPasteboardClient'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+1498345673192	geckodriver	INFO	Listening on 127.0.0.1:56805
+1498345674208	geckodriver::marionette	INFO	Starting browser /Applications/Firefox.app/Contents/MacOS/firefox-bin with args ["-marionette"]
+1498345682497	geckodriver	INFO	Listening on 127.0.0.1:56869
+1498345683488	geckodriver::marionette	INFO	Starting browser /Applications/Firefox.app/Contents/MacOS/firefox-bin with args ["-marionette"]
+1498345685462	Marionette	INFO	Listening on port 56882
+1498345685522	Marionette	WARN	TLS certificate errors will be ignored for this session
+2017-06-24 16:08:05.878 plugin-container[38947:7496472] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9c3b, name = 'com.apple.tsm.portname'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 16:08:05.880 plugin-container[38947:7496472] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9f03, name = 'com.apple.CFPasteboardClient'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+*************************
+A coding exception was thrown and uncaught in a Task.
+
+Full message: TypeError: NetworkError when attempting to fetch resource.
+Full stack: 
+*************************
+1498348483668	geckodriver	INFO	Listening on 127.0.0.1:54526
+1498348484708	geckodriver::marionette	INFO	Starting browser /Applications/Firefox.app/Contents/MacOS/firefox-bin with args ["-marionette"]
+1498348486384	Marionette	INFO	Listening on port 54539
+1498348486429	Marionette	WARN	TLS certificate errors will be ignored for this session
+2017-06-24 16:54:46.873 plugin-container[41113:7528551] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9c37, name = 'com.apple.tsm.portname'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 16:54:46.874 plugin-container[41113:7528551] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9f03, name = 'com.apple.CFPasteboardClient'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 16:55:35.820 firefox-bin[41112:7528467] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:55:35.820 firefox-bin[41112:7528467] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:55:35.821 firefox-bin[41112:7528467] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:55:35.821 firefox-bin[41112:7528467] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:55:35.821 firefox-bin[41112:7528467] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:55:35.821 firefox-bin[41112:7528467] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+1498348565825	geckodriver	INFO	Listening on 127.0.0.1:55022
+1498348566847	geckodriver::marionette	INFO	Starting browser /Applications/Firefox.app/Contents/MacOS/firefox-bin with args ["-marionette"]
+1498348568544	Marionette	INFO	Listening on port 55035
+1498348568652	Marionette	WARN	TLS certificate errors will be ignored for this session
+2017-06-24 16:56:09.008 plugin-container[41186:7530013] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9e3b, name = 'com.apple.tsm.portname'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 16:56:09.009 plugin-container[41186:7530013] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0xa103, name = 'com.apple.CFPasteboardClient'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 16:56:09.463 firefox-bin[41185:7529926] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:56:09.463 firefox-bin[41185:7529926] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:56:09.464 firefox-bin[41185:7529926] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:56:09.464 firefox-bin[41185:7529926] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:56:09.464 firefox-bin[41185:7529926] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:56:09.464 firefox-bin[41185:7529926] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+1498348585911	geckodriver	INFO	Listening on 127.0.0.1:55232
+1498348586914	geckodriver::marionette	INFO	Starting browser /Applications/Firefox.app/Contents/MacOS/firefox-bin with args ["-marionette"]
+2017-06-24 16:56:27.302 firefox-bin[38944:7496342] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:56:27.302 firefox-bin[38944:7496342] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:56:27.303 firefox-bin[38944:7496342] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:56:27.303 firefox-bin[38944:7496342] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:56:27.303 firefox-bin[38944:7496342] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:56:27.303 firefox-bin[38944:7496342] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+1498348588702	Marionette	INFO	Listening on port 55246
+1498348588745	Marionette	WARN	TLS certificate errors will be ignored for this session
+2017-06-24 16:56:29.177 plugin-container[41214:7530576] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9c33, name = 'com.apple.tsm.portname'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 16:56:29.178 plugin-container[41214:7530576] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9f03, name = 'com.apple.CFPasteboardClient'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+1498348595020	geckodriver	INFO	Listening on 127.0.0.1:55328
+1498348596024	geckodriver::marionette	INFO	Starting browser /Applications/Firefox.app/Contents/MacOS/firefox-bin with args ["-marionette"]
+1498348597652	Marionette	INFO	Listening on port 55341
+1498348597720	Marionette	WARN	TLS certificate errors will be ignored for this session
+2017-06-24 16:56:38.098 plugin-container[41235:7530859] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9e3b, name = 'com.apple.tsm.portname'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 16:56:38.098 plugin-container[41235:7530859] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0xa103, name = 'com.apple.CFPasteboardClient'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 16:56:41.135 firefox-bin[41231:7530765] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:56:41.135 firefox-bin[41231:7530765] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:56:41.135 firefox-bin[41231:7530765] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:56:41.135 firefox-bin[41231:7530765] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:56:41.136 firefox-bin[41231:7530765] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:56:41.136 firefox-bin[41231:7530765] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+1498348616704	geckodriver	INFO	Listening on 127.0.0.1:55472
+1498348617718	geckodriver::marionette	INFO	Starting browser /Applications/Firefox.app/Contents/MacOS/firefox-bin with args ["-marionette"]
+2017-06-24 16:56:59.341 firefox-bin[41263:7531332] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:56:59.341 firefox-bin[41263:7531332] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:56:59.342 firefox-bin[41263:7531332] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:56:59.342 firefox-bin[41263:7531332] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:56:59.342 firefox-bin[41263:7531332] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:56:59.343 firefox-bin[41263:7531332] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+1498348619555	Marionette	INFO	Listening on port 55485
+1498348619731	Marionette	WARN	TLS certificate errors will be ignored for this session
+2017-06-24 16:57:00.193 plugin-container[41265:7531421] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9e3b, name = 'com.apple.tsm.portname'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 16:57:00.194 plugin-container[41265:7531421] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0xa103, name = 'com.apple.CFPasteboardClient'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+JavaScript error: chrome://global/content/browser-child.js, line 294: NS_ERROR_UNKNOWN_PROTOCOL: Component returned failure code: 0x804b0012 (NS_ERROR_UNKNOWN_PROTOCOL) [nsIWebNavigation.goBack]
+1498348703492	geckodriver	INFO	Listening on 127.0.0.1:56279
+1498348704507	geckodriver::marionette	INFO	Starting browser /Applications/Firefox.app/Contents/MacOS/firefox-bin with args ["-marionette"]
+1498348706137	Marionette	INFO	Listening on port 56292
+1498348706199	Marionette	WARN	TLS certificate errors will be ignored for this session
+2017-06-24 16:58:26.522 plugin-container[41342:7532828] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9c3b, name = 'com.apple.tsm.portname'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 16:58:26.523 plugin-container[41342:7532828] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9f03, name = 'com.apple.CFPasteboardClient'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 16:58:32.666 firefox-bin[41340:7532745] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:58:32.666 firefox-bin[41340:7532745] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:58:32.667 firefox-bin[41340:7532745] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:58:32.667 firefox-bin[41340:7532745] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:58:32.667 firefox-bin[41340:7532745] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:58:32.667 firefox-bin[41340:7532745] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+1498348748844	geckodriver	INFO	Listening on 127.0.0.1:56607
+1498348749867	geckodriver::marionette	INFO	Starting browser /Applications/Firefox.app/Contents/MacOS/firefox-bin with args ["-marionette"]
+1498348751558	Marionette	INFO	Listening on port 56621
+1498348751661	Marionette	WARN	TLS certificate errors will be ignored for this session
+2017-06-24 16:59:11.942 plugin-container[41402:7533702] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9e3b, name = 'com.apple.tsm.portname'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 16:59:11.943 plugin-container[41402:7533702] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0xa103, name = 'com.apple.CFPasteboardClient'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 16:59:28.540 firefox-bin[41400:7533604] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:59:28.540 firefox-bin[41400:7533604] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:59:28.540 firefox-bin[41400:7533604] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:59:28.540 firefox-bin[41400:7533604] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:59:28.541 firefox-bin[41400:7533604] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 16:59:28.541 firefox-bin[41400:7533604] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+1498348797600	geckodriver	INFO	Listening on 127.0.0.1:56950
+1498348798633	geckodriver::marionette	INFO	Starting browser /Applications/Firefox.app/Contents/MacOS/firefox-bin with args ["-marionette"]
+1498348800488	Marionette	INFO	Listening on port 56963
+1498348800552	Marionette	WARN	TLS certificate errors will be ignored for this session
+2017-06-24 17:00:00.885 plugin-container[41460:7534756] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9e3b, name = 'com.apple.tsm.portname'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 17:00:00.886 plugin-container[41460:7534756] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0xa103, name = 'com.apple.CFPasteboardClient'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 17:00:01.192 firefox-bin[41457:7534613] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 17:00:01.192 firefox-bin[41457:7534613] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 17:00:01.192 firefox-bin[41457:7534613] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 17:00:01.192 firefox-bin[41457:7534613] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 17:00:01.193 firefox-bin[41457:7534613] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 17:00:01.193 firefox-bin[41457:7534613] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+1498348823493	geckodriver	INFO	Listening on 127.0.0.1:57200
+1498348824494	geckodriver::marionette	INFO	Starting browser /Applications/Firefox.app/Contents/MacOS/firefox-bin with args ["-marionette"]
+1498348826098	Marionette	INFO	Listening on port 57213
+1498348826186	Marionette	WARN	TLS certificate errors will be ignored for this session
+2017-06-24 17:00:26.727 plugin-container[41505:7535348] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9e3b, name = 'com.apple.tsm.portname'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 17:00:26.728 plugin-container[41505:7535348] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0xa103, name = 'com.apple.CFPasteboardClient'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 17:00:28.348 firefox-bin[41504:7535257] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 17:00:28.348 firefox-bin[41504:7535257] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 17:00:28.349 firefox-bin[41504:7535257] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 17:00:28.349 firefox-bin[41504:7535257] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 17:00:28.349 firefox-bin[41504:7535257] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 17:00:28.349 firefox-bin[41504:7535257] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+1498352128159	geckodriver	INFO	Listening on 127.0.0.1:50178
+1498352129182	geckodriver::marionette	INFO	Starting browser /Applications/Firefox.app/Contents/MacOS/firefox-bin with args ["-marionette"]
+2017-06-24 17:55:30.959 firefox-bin[42681:7559037] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 17:55:30.959 firefox-bin[42681:7559037] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 17:55:30.959 firefox-bin[42681:7559037] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 17:55:30.960 firefox-bin[42681:7559037] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 17:55:30.960 firefox-bin[42681:7559037] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 17:55:30.960 firefox-bin[42681:7559037] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+1498352131260	Marionette	INFO	Listening on port 50191
+1498352131468	Marionette	WARN	TLS certificate errors will be ignored for this session
+2017-06-24 17:55:31.744 plugin-container[42682:7559126] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9c3b, name = 'com.apple.tsm.portname'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 17:55:31.745 plugin-container[42682:7559126] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9f03, name = 'com.apple.CFPasteboardClient'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+1498352145918	geckodriver	INFO	Listening on 127.0.0.1:50380
+1498352146918	geckodriver::marionette	INFO	Starting browser /Applications/Firefox.app/Contents/MacOS/firefox-bin with args ["-marionette"]
+1498352148549	Marionette	INFO	Listening on port 50393
+1498352148615	Marionette	WARN	TLS certificate errors will be ignored for this session
+2017-06-24 17:55:48.939 plugin-container[42718:7560001] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9c3b, name = 'com.apple.tsm.portname'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 17:55:48.940 plugin-container[42718:7560001] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9f03, name = 'com.apple.CFPasteboardClient'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 17:55:51.811 firefox-bin[42717:7559896] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 17:55:51.811 firefox-bin[42717:7559896] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 17:55:51.812 firefox-bin[42717:7559896] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 17:55:51.812 firefox-bin[42717:7559896] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 17:55:51.812 firefox-bin[42717:7559896] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 17:55:51.812 firefox-bin[42717:7559896] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+1498352181297	geckodriver	INFO	Listening on 127.0.0.1:50653
+1498352182314	geckodriver::marionette	INFO	Starting browser /Applications/Firefox.app/Contents/MacOS/firefox-bin with args ["-marionette"]
+1498352183975	Marionette	INFO	Listening on port 50666
+1498352184034	Marionette	WARN	TLS certificate errors will be ignored for this session
+2017-06-24 17:56:24.376 plugin-container[42769:7560907] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9c3b, name = 'com.apple.tsm.portname'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 17:56:24.377 plugin-container[42769:7560907] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9f03, name = 'com.apple.CFPasteboardClient'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+JavaScript error: http://localhost:8001/static/6268587/edx-ui-toolkit/js/utils/string-utils.js, line 77: ReferenceError: edx is not defined
+JavaScript error: http://localhost:8001/static/6268587/edx-ui-toolkit/js/utils/html-utils.js, line 242: ReferenceError: edx is not defined
+2017-06-24 18:01:26.058 firefox-bin[42768:7560819] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:01:26.058 firefox-bin[42768:7560819] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:01:26.059 firefox-bin[42768:7560819] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:01:26.059 firefox-bin[42768:7560819] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:01:26.060 firefox-bin[42768:7560819] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:01:26.060 firefox-bin[42768:7560819] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+1498352606729	geckodriver	INFO	Listening on 127.0.0.1:52551
+1498352607748	geckodriver::marionette	INFO	Starting browser /Applications/Firefox.app/Contents/MacOS/firefox-bin with args ["-marionette"]
+1498352609524	Marionette	INFO	Listening on port 52568
+1498352609567	Marionette	WARN	TLS certificate errors will be ignored for this session
+2017-06-24 18:03:29.962 plugin-container[42937:7565106] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9e3b, name = 'com.apple.tsm.portname'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 18:03:29.962 plugin-container[42937:7565106] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0xa103, name = 'com.apple.CFPasteboardClient'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 18:03:32.629 firefox-bin[42936:7565010] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:03:32.629 firefox-bin[42936:7565010] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:03:32.629 firefox-bin[42936:7565010] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:03:32.629 firefox-bin[42936:7565010] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:03:32.630 firefox-bin[42936:7565010] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:03:32.630 firefox-bin[42936:7565010] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+1498352632988	geckodriver	INFO	Listening on 127.0.0.1:52795
+1498352633996	geckodriver::marionette	INFO	Starting browser /Applications/Firefox.app/Contents/MacOS/firefox-bin with args ["-marionette"]
+1498352635640	Marionette	INFO	Listening on port 52808
+1498352635709	Marionette	WARN	TLS certificate errors will be ignored for this session
+2017-06-24 18:03:56.027 plugin-container[42980:7565835] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9e3b, name = 'com.apple.tsm.portname'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 18:03:56.028 plugin-container[42980:7565835] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0xa103, name = 'com.apple.CFPasteboardClient'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 18:03:56.126 firefox-bin[42975:7565738] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:03:56.126 firefox-bin[42975:7565738] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:03:56.127 firefox-bin[42975:7565738] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:03:56.127 firefox-bin[42975:7565738] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:03:56.127 firefox-bin[42975:7565738] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:03:56.127 firefox-bin[42975:7565738] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+1498352889094	geckodriver	INFO	Listening on 127.0.0.1:55096
+1498352890115	geckodriver::marionette	INFO	Starting browser /Applications/Firefox.app/Contents/MacOS/firefox-bin with args ["-marionette"]
+1498352891794	Marionette	INFO	Listening on port 55113
+1498352891843	Marionette	WARN	TLS certificate errors will be ignored for this session
+2017-06-24 18:08:12.184 plugin-container[43103:7568867] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9c3b, name = 'com.apple.tsm.portname'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 18:08:12.185 plugin-container[43103:7568867] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9f03, name = 'com.apple.CFPasteboardClient'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 18:08:22.540 firefox-bin[43101:7568781] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:08:22.540 firefox-bin[43101:7568781] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:08:22.541 firefox-bin[43101:7568781] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:08:22.541 firefox-bin[43101:7568781] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:08:22.542 firefox-bin[43101:7568781] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:08:22.542 firefox-bin[43101:7568781] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+1498352964942	geckodriver	INFO	Listening on 127.0.0.1:55550
+1498352965964	geckodriver::marionette	INFO	Starting browser /Applications/Firefox.app/Contents/MacOS/firefox-bin with args ["-marionette"]
+1498352967679	Marionette	INFO	Listening on port 55563
+1498352967766	Marionette	WARN	TLS certificate errors will be ignored for this session
+2017-06-24 18:09:28.089 plugin-container[43213:7570060] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9c33, name = 'com.apple.tsm.portname'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 18:09:28.090 plugin-container[43213:7570060] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9f03, name = 'com.apple.CFPasteboardClient'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 18:09:33.669 firefox-bin[43211:7569969] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:09:33.669 firefox-bin[43211:7569969] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:09:33.670 firefox-bin[43211:7569969] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:09:33.670 firefox-bin[43211:7569969] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:09:33.671 firefox-bin[43211:7569969] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:09:33.671 firefox-bin[43211:7569969] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+1498353015717	geckodriver	INFO	Listening on 127.0.0.1:55906
+1498353016729	geckodriver::marionette	INFO	Starting browser /Applications/Firefox.app/Contents/MacOS/firefox-bin with args ["-marionette"]
+1498353018368	Marionette	INFO	Listening on port 55919
+1498353018428	Marionette	WARN	TLS certificate errors will be ignored for this session
+2017-06-24 18:10:18.758 plugin-container[43277:7570872] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9c3b, name = 'com.apple.tsm.portname'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 18:10:18.758 plugin-container[43277:7570872] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9f03, name = 'com.apple.CFPasteboardClient'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+1498353645506	geckodriver	INFO	Listening on 127.0.0.1:59372
+1498353646528	geckodriver::marionette	INFO	Starting browser /Applications/Firefox.app/Contents/MacOS/firefox-bin with args ["-marionette"]
+1498353648256	Marionette	INFO	Listening on port 59389
+1498353648330	Marionette	WARN	TLS certificate errors will be ignored for this session
+2017-06-24 18:20:48.655 plugin-container[43590:7576946] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9e3b, name = 'com.apple.tsm.portname'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 18:20:48.656 plugin-container[43590:7576946] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0xa103, name = 'com.apple.CFPasteboardClient'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+*************************
+A coding exception was thrown and uncaught in a Task.
+
+Full message: TypeError: NetworkError when attempting to fetch resource.
+Full stack: 
+*************************
+1498353943037	geckodriver	INFO	Listening on 127.0.0.1:60755
+1498353944060	geckodriver::marionette	INFO	Starting browser /Applications/Firefox.app/Contents/MacOS/firefox-bin with args ["-marionette"]
+1498353945761	Marionette	INFO	Listening on port 60768
+1498353945862	Marionette	WARN	TLS certificate errors will be ignored for this session
+2017-06-24 18:25:46.161 plugin-container[43907:7580373] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9c3b, name = 'com.apple.tsm.portname'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+2017-06-24 18:25:46.161 plugin-container[43907:7580373] *** CFMessagePort: bootstrap_register(): failed 1100 (0x44c) 'Permission denied', port = 0x9f03, name = 'com.apple.CFPasteboardClient'
+See /usr/include/servers/bootstrap_defs.h for the error codes.
+1498353948069	Marionette	INFO	New connections will no longer be accepted
+[GFX1-]: Receive IPC close with reason=AbnormalShutdown
+2017-06-24 18:25:57.745 firefox-bin[43587:7576842] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:25:57.745 firefox-bin[43587:7576842] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:25:57.745 firefox-bin[43587:7576842] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:25:57.745 firefox-bin[43587:7576842] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:25:57.746 firefox-bin[43587:7576842] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:25:57.746 firefox-bin[43587:7576842] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:26:00.554 firefox-bin[43272:7570774] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:26:00.554 firefox-bin[43272:7570774] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:26:00.554 firefox-bin[43272:7570774] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:26:00.554 firefox-bin[43272:7570774] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:26:00.555 firefox-bin[43272:7570774] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
+2017-06-24 18:26:00.555 firefox-bin[43272:7570774] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 7. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.

--- a/launchcontainer/launchcontainer.py
+++ b/launchcontainer/launchcontainer.py
@@ -126,14 +126,11 @@ class LaunchContainerXBlock(XBlock):
         # If this does not work, it's possible that get_current_site() below
         # will get the incorrect site, which should not contain a WHARF_URL_KEY,
         # thereby causing this code to Fallback to the DEFAULT_WHARF_URL.
-        # TODO: Can we hook into edX's RequestCache? See: https://git.io/vH7Zf
         try:
+            # TODO: Can we hook into edX's RequestCache? See: https://git.io/vH7Zf
             edx_site_domain = "{}.{}".format(self.course_id.org, settings.LMS_BASE)
-        except AttributeError:  # We're probably on the lms side: no settings.LMS_BASE.
-            edx_site_domain = None
-        try:
             site = Site.objects.get(domain=edx_site_domain)
-        except Site.DoesNotExist:
+        except (Site.DoesNotExist, AttributeError):  # Probably on the lms side.
             if get_current_site:
                 site = get_current_site()  # From the request.
             else:

--- a/launchcontainer/static/html/launchcontainer_edit.html
+++ b/launchcontainer/static/html/launchcontainer_edit.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<div class="wrapper-comp-settings is-active editor-with-buttons" id="settings-tab">
+<div class="xblock-launchcontainer wrapper-comp-settings is-active editor-with-buttons" id="settings-tab">
 
   <form id="#launch-container-edit-form">
     <ul class="list-input settings-list" style="height: auto">

--- a/launchcontainer/static/js/src/launchcontainer_edit.js
+++ b/launchcontainer/static/js/src/launchcontainer_edit.js
@@ -1,51 +1,35 @@
 function LaunchContainerEditBlock(runtime, element) {
 
-    console.log($('.xblock-save-button', element));
-
-    function notify(response) {
-        var $notificationEl = $('#notification-message'); 
-        var $editModal = $('.wrapper.wrapper-modal-window.wrapper-modal-window-edit-xblock');
-        var $editModalOverlay = $('.modal-window-overlay');
-        var $displayHeader = $('.xblock-header.xblock-header-launchcontainer .header-details');
-        var $editSuccessContent = "Your changes have been successfully applied. "
-                                  + "Please refresh and then click the button above to test.";
-        var $launcherNotification = $('#launcher_notification');
-
-        if (response.result === 'success') {
-          // class="ui-loading is-hidden"
-          
-          // Hide the modal in the Studio interface.
-//          $notificationEl.find('span').html('Your request was successful.');
-          $editModal.addClass('is-hidden');
-          $editModalOverlay.addClass('is-hidden');
-          $launcherNotification.text($editSuccessContent);
-          $launcherNotification.addClass('ui-state-highlight')
-                               .removeClass('ui-state-error')
-                               .removeClass('hide');
-          $('#launcher_form').removeClass('hide');
-        }
-        else {
-          $notificationEl.addClass('error').removeClass('hide').removeClass('is-hidden');
-          $notificationEl.html("It didn't work! "+response.result); 
-        }
-    }
-
+    // Handle the save button click.
     $('.save-button', element).bind('click', function() {
         var handlerUrl = runtime.handlerUrl(element, 'studio_submit');
         var data = {
-            'project': $('#project_input').val(),
-            'project_friendly': $('#project_friendly_input').val(),
-            'project_token': $('#project_token_input').val(),
+          'project': $('#project_input').val(),
+          'project_friendly': $('#project_friendly_input').val(),
+          'project_token': $('#project_token_input').val()
         };
 
         $.post(handlerUrl, JSON.stringify(data))
           .done(function(response) { 
-              notify(response);
-        });
+            if (response.result === 'success') {
+              // We force the page to reload because the XBlock runtime 
+              // doesn't handle this properly if your are in a unit: https://git.io/vQ4Kj.
+              window.location.reload();
+            } else {
+              runtime.notify('error', {message: 'Error: '+response.result});
+            }
+          });
     });
 
+    // Handle the cancel button click.
     $('.cancel-button', element).bind('click', function() {
         runtime.notify('cancel', {});
     });
-}
 
+    // Allow the escape key to close the XBlock form.
+    $(document).keyup(function(e) {
+      if (e.keyCode == 27) {
+        runtime.notify('cancel');
+      }
+    });
+}

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-launchcontainer',
-    version='1.1.9',
+    version='2.2',
     author='Bryan Wilson, Jazkarta',
     description=('Open EdX XBlock to display a button allowing an LMS user '
                  'to launch and link to an external courseware resource via the '


### PR DESCRIPTION
edX has a nice (though poorly documented!) APIs
for showing notifications to the user, which are
just not quite ready for our use.

Long story short: I did a bunch of stuff to make my own notifications, then attempted to use edX's notifications, then decided to just reload the page. It's not ideal, but this is where I want to leave it for this release. 