### PR TITLE
Drop the default url

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -82,6 +82,8 @@ You should then be able to take the title and the token of a Wharf project, and 
 
 *TODO: Insert screenshot of sdk studio_view.*
 
+TODO: How to run the tests, including adding django.contrib.site. This should be in the dependencies, too.
+
 ## INSTALL FOR DEVSTACK DEVELOPMENT 
 
 *Tested with Eucalyptus.*

--- a/launchcontainer/launchcontainer.py
+++ b/launchcontainer/launchcontainer.py
@@ -188,8 +188,10 @@ class LaunchContainerXBlock(XBlock):
             logger.debug("Current site config enabled: {}".format(
                 is_site_configuration_enabled())
             )
-            logger.debug("Current site config LAUNCHCONTAINER_WHARF_URL: {}".format(
-                siteconfig_helpers.get_value('LAUNCHCONTAINER_WHARF_URL')))
+            logger.debug("Current site config {} LAUNCHCONTAINER_WHARF_URL: {}".format(
+                WHARF_URL_KEY,
+                siteconfig_helpers.get_value(WHARF_URL_KEY))
+            )
 
         return url
 
@@ -309,9 +311,15 @@ def update_wharf_url_cache(sender, **kwargs):
     """
     Receiver that will update the cache item that contains
     this site's WHARF_URL_KEY.
+
+    TODO: This function could use a test or two once they are running in the edx
+    environment.
     """
     instance = kwargs['instance']
-    new_key = instance.values.get(WHARF_URL_KEY)
+
+    new_key = False
+    if hasattr(instance, 'values') and instance.values:
+        new_key = instance.values.get(WHARF_URL_KEY)
     if new_key:
         cache.set(make_cache_key(instance.site.domain),
                   instance.values.get(WHARF_URL_KEY),


### PR DESCRIPTION
This removes the default URL from launchcontainer.py, forcing it to be set either in the database, or in the ENV_TOKENS. If it is not set, the the xblock library will catch and show an error to the user as below. 

**Note**: This will not be released until we have confirmed that all servers are in fact setting this var (via [this card](https://trello.com/c/WDIkxD5R/1120-12-set-up-a-plan-for-deploying-the-xblock-and-test-it-part-2)).

<img width="998" alt="screenshot 2017-07-01 18 42 14" src="https://user-images.githubusercontent.com/1884902/27766663-0635fca2-5e8d-11e7-821a-6310d9f36ca8.png">

https://trello.com/c/vgUe4fUX/1132-2-get-rid-of-the-default-url-in-the-xblock
