### PR TITLE
[WIP] Style all the error messages

### DIFF
--- a/launchcontainer/static/css/launchcontainer.css
+++ b/launchcontainer/static/css/launchcontainer.css
@@ -1,5 +1,5 @@
-.hide {
-  display: none;
+.is-hidden {
+  display: none !important;
 }
 
 .wraptext {
@@ -13,9 +13,6 @@ div#launcher_notification, .launcher-form--container {
   margin: 10px 0;
 }
 
-div#launcher_notification { 
-  display: inline-block;
-}
 
 div#launcher_notification p {
   margin-bottom: 0;
@@ -23,6 +20,11 @@ div#launcher_notification p {
 
 #launcher_submit {
   padding: 10px;
+}
+
+/********* Utils ************/
+.u-display-inline-block {
+  display: inline-block;
 }
 
 /********* Alerts ***********/
@@ -42,7 +44,7 @@ div#launcher_notification p {
   margin: 1.5rem 0;
 }
 
-.launch-alert .icon { 
+.launch-alert .launch-alert--icon { 
   float: left;
   display: block;
   border-radius: 50%;
@@ -68,7 +70,7 @@ div#launcher_notification p {
   box-shadow: inset 0 0 0 0.25rem #feeced;
 }
 
-.launch-alert--error .icon { 
+.launch-alert--error .launch-alert--icon { 
   background-color: #cb0712;
 }
 
@@ -79,7 +81,7 @@ div#launcher_notification p {
   box-shadow: inset 0 0 0 0.25rem #ddf3ff;
 }
 
-.launch-alert--information .icon { 
+.launch-alert--information .launch-alert--icon { 
   background-color: #0086ce;
 }
 
@@ -90,6 +92,6 @@ div#launcher_notification p {
   box-shadow: inset 0 0 0 0.25rem #ecfaec;
 }
 
-.launch-alert--success .icon {
+.launch-alert--success .launch-alert--icon {
   background-color: #009b00;
 }

--- a/launchcontainer/static/css/launchcontainer.css
+++ b/launchcontainer/static/css/launchcontainer.css
@@ -8,9 +8,12 @@
   padding: 5px;
 }
 
-div#launcher_notification {
+div#launcher_notification, .launcher-form--container {
   padding: 10px;
   margin: 10px 0;
+}
+
+div#launcher_notification { 
   display: inline-block;
 }
 
@@ -20,4 +23,73 @@ div#launcher_notification p {
 
 #launcher_submit {
   padding: 10px;
+}
+
+/********* Alerts ***********/
+
+.launch-alert { 
+  overflow: auto;
+  padding: 1.25rem;
+}
+
+.launch-alert--message { 
+  width: 80%;
+  padding: 1.25rem;
+  float: left;
+}
+
+.launch-alert--message p {
+  margin: 1.5rem 0;
+}
+
+.launch-alert .icon { 
+  float: left;
+  display: block;
+  border-radius: 50%;
+  padding: .625rem;
+  margin: 1.4rem 0 0 0;
+  color: #fff;
+}
+
+.launch-alert--errorList {
+  list-style: disc outside none;
+  margin: 1em 0;
+  padding: 0 0 0 1em;
+}
+
+.launch-alert--errorList .launch-alert--errorListItem {
+  margin-bottom: 0.7em;
+}
+
+/* Alert: Error */
+
+.launch-alert.launch-alert--error {
+  border: .0625rem solid #cb0712;
+  box-shadow: inset 0 0 0 0.25rem #feeced;
+}
+
+.launch-alert--error .icon { 
+  background-color: #cb0712;
+}
+
+/* Alert: Information */ 
+
+.launch-alert.launch-alert--information { 
+  border: .0625rem solid #0086ce;
+  box-shadow: inset 0 0 0 0.25rem #ddf3ff;
+}
+
+.launch-alert--information .icon { 
+  background-color: #0086ce;
+}
+
+/* Alert: Success */ 
+
+.launch-alert.launch-alert--success {
+  border: .0625rem solid #009b00;
+  box-shadow: inset 0 0 0 0.25rem #ecfaec;
+}
+
+.launch-alert--success .icon {
+  background-color: #009b00;
 }

--- a/launchcontainer/static/html/launchcontainer.html
+++ b/launchcontainer/static/html/launchcontainer.html
@@ -2,9 +2,17 @@
   <iframe src="{{ API_url }}" style="visibility: hidden" width="0" height="0"></iframe>
   <div class="launcher-form--container">
     <form id="launcher_form">
-      <input type="text" class="hide" id="launcher_email" name="owner_email" {% if user_email %}value="{{ user_email }}"{% endif %} placeholder="Please enter your email address" />
+      <input type="text" class="is-hidden" id="launcher_email" name="owner_email" {% if user_email %}value="{{ user_email }}"{% endif %} placeholder="Please enter your email address" />
       <button type="submit" class="ui-priority-primary" id="launcher_submit">Click to launch your {{ project_friendly }} lab</button>
     </form>
   </div>
-  <div id="launcher_notification" class="hide"></div>
+  <div id="launcher_notification" class="is-hidden u-display-inline-block"> 
+    <div class='launch-alert launch-alert--information'>
+      <span class='launch-alert--icon fa fa-bullhorn'></span>
+      <div class='launch-alert--message'>
+        <h3 class='launch-alert--title'>Notification Placeholder</h3>
+        <p class='launch-alert--body'>Message placeholder</p>
+      </div>
+    </div>
+  </div>
 </div>

--- a/launchcontainer/static/html/launchcontainer.html
+++ b/launchcontainer/static/html/launchcontainer.html
@@ -12,6 +12,9 @@
       <div class='launch-alert--message'>
         <h3 class='launch-alert--title'>Notification Placeholder</h3>
         <p class='launch-alert--body'>Message placeholder</p>
+        <ul class='launch-alert--errorList is-hidden'>
+          <li class='launch-alert--errorListItem is-hidden'></li>
+        </ul>
       </div>
     </div>
   </div>

--- a/launchcontainer/static/html/launchcontainer.html
+++ b/launchcontainer/static/html/launchcontainer.html
@@ -1,10 +1,10 @@
 <div id="launcher1">
   <iframe src="{{ API_url }}" style="visibility: hidden" width="0" height="0"></iframe>
-  <form id="launcher_form">
-    <input type="text" class="hide" id="launcher_email" name="owner_email" {% if user_email %}value="{{ user_email }}"{% endif %} placeholder="Please enter your email address" />
-    <input type="text" class="hide" id="launcher_project" name="project" value="{{ project }}" />
-    <input type="text" class="hide" id="launcher_token" name="token" value="{{ project_token }}" />
-    <button type="submit" class="ui-priority-primary" id="launcher_submit">Click to launch your {{ project_friendly }} lab</button>
-  </form>
+  <div class="launcher-form--container">
+    <form id="launcher_form">
+      <input type="text" class="hide" id="launcher_email" name="owner_email" {% if user_email %}value="{{ user_email }}"{% endif %} placeholder="Please enter your email address" />
+      <button type="submit" class="ui-priority-primary" id="launcher_submit">Click to launch your {{ project_friendly }} lab</button>
+    </form>
+  </div>
   <div id="launcher_notification" class="hide"></div>
 </div>

--- a/launchcontainer/static/js/src/launchcontainer.js
+++ b/launchcontainer/static/js/src/launchcontainer.js
@@ -10,15 +10,29 @@ function LaunchContainerXBlock(runtime, element) {
 
   $(document).ready(
     function () {
-      // Submit the data to the AVL server and process the response. //
+
+      // This is a template for rendering messages to the user.
+      var _notification_template = function ($type, $title, $message) {
+        var $iconMap = {'error': 'warning', 'information': 'bullhorn', 'success': 'check'}
+        var $renderedTemplate = "<div class='launch-alert launch-alert--"+$type+"'>"
+                                + "<span class='icon alert-icon fa fa-"+$iconMap[$type]+"'></span>"
+                                  + "<div class='launch-alert--message'>"
+                                    + "<h3>"+$title+"</h3>"
+                                    + "<p>" 
+                                      + $message
+                                    + "</p>" 
+                                  + "</div>"
+                                + "</div>"
+        return $renderedTemplate
+      }
+
+      // Submit the data to the AVL server and process the response.
       var $launcher = $('#launcher1'),
           $post_url = '{{ API_url|escapejs }}',
           $launcher_form = $('#launcher_form'),
           $launcher_submit = $('#launcher_submit'),
           $launcher_email = $('#launcher_email'),
-          $launch_notification = $('#launcher_notification'), 
-          $waiting = 'Your request for a lab is being processed, and may take up to 90 seconds to start. '
-          + 'If you are having issues, please contact the administrator.'
+          $launch_notification = $('#launcher_notification') 
 
       // This is for the xblock-sdk: If there is no email addy, 
       // you can enter it manually.
@@ -32,10 +46,18 @@ function LaunchContainerXBlock(runtime, element) {
         event.preventDefault();
         $launcher_submit.disabled = true; 
         $launcher_submit.text('Launching ...');
-        $launch_notification.html($waiting);
-        $launch_notification.removeClass('hide')
-                            .removeClass('ui-state-error')
-                            .removeClass('ui-state-notification');
+
+        // Add notification message.
+        $message = _notification_template(
+          'information', 
+          'Your request is being processed', 
+          'This can take up to 90 seconds--thank you for your patience! '
+          + 'If you are having issues, please contact the administrator.'
+        )
+        $launch_notification.html($message);
+        $launch_notification.removeClass('hide');
+
+        // Post the message to the iframe.
         $launch_iframe = $launcher.find('iframe')[0];
         $launch_iframe.contentWindow.postMessage({
           'project': "{{ project|escapejs }}",
@@ -49,32 +71,40 @@ function LaunchContainerXBlock(runtime, element) {
       window.addEventListener("message", function (event) {
         if (event.origin !== getURLOrigin('{{ API_url|escapejs }}')) return;
         if(event.data.status === 'siteDeployed') {
-          $launch_notification.removeClass('hide')
-                              .removeClass('ui-state-error')
-                              .html(event.data.html_content);
-          // The inner iframe takes care of posting the message, 
-          // so we just need to hide the form.
+          $message = _notification_template(
+            'success', 'Success', 
+            event.data.html_content
+          ); 
+          $launch_notification.html($message);
+          $launch_notification.removeClass('hide');
           $launcher_form.addClass('hide');
         } else if(event.data.status === 'deploymentError') {
           var $status_code = event.data.status_code;
           var $msg;
           if ($status_code === 400) {
+            var $errorList = $("<ul class='launch-alert--errorList'>");
             var $errors = event.data.errors;
             for (i=0; i<$errors.length; i++) { 
-              $msg = $errors[i][0] + ": " + $errors[i][1][0] + " "; 
+              $errorList.append($("<li class='launch-alert--errorListItem'>")
+                                .text($errors[i][0] + ": " + $errors[i][1][0])
+                               ); 
             }
+            $msg = $errorList.prop('outerHTML');
           } else if ($status_code === 403) {
             $msg = "Your request failed because the token sent with "
-                        +"your request is invalid. "
+                   + "your request is invalid. "
           } else if ($status_code === 404) {
             $msg = "That project was not found. "; 
           } else if ($status_code === 503) {
             $msg = event.data.errors + " ";
           }
-          var $final_msg = "<p class='error'>An error occured in your request: " + $msg + "</p>" 
-                           + "<p> Please contact the administrator.</p>";
-          $launch_notification.html($final_msg);
-          $launch_notification.addClass('ui-state-error').removeClass('hide');
+          var $message = _notification_template(
+            'error', 'Error', 
+            "An error occured in your request: " + $msg + "Please contact the administrator."
+          )
+            
+          $launch_notification.html($message);
+          $launch_notification.removeClass('hide');
         }
       }, false);
     });

--- a/launchcontainer/static/js/src/launchcontainer.js
+++ b/launchcontainer/static/js/src/launchcontainer.js
@@ -11,38 +11,58 @@ function LaunchContainerXBlock(runtime, element) {
   $(document).ready(
     function () {
 
-      var _show_notification = function ($type, $title, $message, $html) {
+      var _show_notification = function (type, params) {
         // Toggle the message that is shown to the user. 
-        $message = $message || undefined; 
-        $html = $html || undefined;
-        var $iconMap = {'error': 'warning', 'information': 'bullhorn', 'success': 'check'};
+        
+        var title = params.title, 
+            textMessage = params.textMessage || undefined, 
+            htmlMessage = params.htmlMessage || undefined, 
+            errors = params.errors || undefined,
+            iconMap = {
+              'error': 'warning', 
+              'information': 'bullhorn', 
+              'success': 'check'
+            };
+
         // Segments of a class need to be overwritten, so I just drop all the classes instead
         // of e.g. a regex. 
         // attr() is used instead of removeClass() because a bug in jQuery UI 1.10.0: 
         // https://bugs.jqueryui.com/ticket/9015 
-        $('div.launch-alert').attr('class', 'launch-alert launch-alert--' + $type); 
-        $('span.launch-alert--icon').attr('class', 'launch-alert--icon fa fa-' + $iconMap[$type]); 
-        $('h3.launch-alert--title').text($title);
+        $('div.launch-alert').attr('class', 'launch-alert launch-alert--' + type); 
+        $('span.launch-alert--icon').attr('class', 'launch-alert--icon fa fa-' + iconMap[type]); 
+        $('h3.launch-alert--title').text(title);
 
-        if ($message) {
-          $('p.launch-alert--body').text($message);
-        } else if ($html) {
+        if (textMessage) {
+          $('p.launch-alert--body').text(textMessage);
+        } else if (htmlMessage) {
           // This html only comes from us and ISC, for now. 
           // In the near future we need to remedy this, though, 
-          // for Tahoe, by returning.
-          $('p.launch-alert--body').html($html);
-        };
+          // for Tahoe, by modifying the Wharf interface to disallow html, 
+          // or use Django to sanitize it?
+          $('p.launch-alert--body').html(htmlMessage);
+        }
+
+        if (errors) {
+          var errorListItems = [], 
+              errorListEl = $('.launch-alert--errorListItem')[0];
+          for (i=0; i<$errors.length; i++) { 
+            errorListItems.append($(errorListEl).clone()
+              .text($errors[i][0] + ": " + $errors[i][1][0])
+              .removeClass('is-hidden')
+            );
+          }
+          $('ul.launch-alert--errorList').append(errorItems).removeClass('is-hidden');
+        }
 
         $('#launcher_notification').removeClass('is-hidden');
-      }
+      };
 
       // Submit the data to the AVL server and process the response.
       var $launcher = $('#launcher1'),
           $post_url = '{{ API_url|escapejs }}',
-          $launcher_form = $('#launcher_form'),
           $launcher_submit = $('#launcher_submit'),
           $launcher_email = $('#launcher_email'),
-          $launch_notification = $('#launcher_notification') 
+          $launch_notification = $('#launcher_notification');
 
       // This is for the xblock-sdk: If there is no email addy, 
       // you can enter it manually.
@@ -59,16 +79,17 @@ function LaunchContainerXBlock(runtime, element) {
 
         // Add notification message.
         _show_notification(
-          'information', 
-          'Your request is being processed', 
-          'This can take up to 90 seconds--thank you for your patience! '
-          + 'If you are having issues, please contact the administrator.'
-        )
+          'information', {
+            title: 'Your request is being processed', 
+            textMessage: 'This can take up to 90 seconds--thank you for your patience! ' + 
+                         'If you are having issues, please contact the administrator.'
+          }
+        );
 
         // Post the message to the iframe.
         $launch_iframe = $launcher.find('iframe')[0];
         $launch_iframe.contentWindow.postMessage({
-          'project': "{{ project|escapejs }}",
+//          'project': "{{ project|escapejs }}",
           'owner_email': "{{ user_email|escapejs }}",
           'token': "{{ project_token|escapejs }}"
           }, "{{ API_url|escapejs }}"
@@ -78,39 +99,53 @@ function LaunchContainerXBlock(runtime, element) {
 
       window.addEventListener("message", function (event) {
         if (event.origin !== getURLOrigin('{{ API_url|escapejs }}')) return;
-        if(event.data.status === 'siteDeployed') {
+        if (event.data.status === 'siteDeployed') {
           _show_notification(
-            'success', 'Success', null,
-            event.data.html_content
-          ); 
-          $launcher_form.addClass('is-hidden');
-        } else if(event.data.status === 'deploymentError') {
-          var $status_code = event.data.status_code;
-          var $msg;
-          if ($status_code === 400) {
-            // xx
-            var $errorList = $("<ul class='launch-alert--errorList'>");
-            var $errors = event.data.errors;
-            for (i=0; i<$errors.length; i++) { 
-              $errorList.append($("<li class='launch-alert--errorListItem'>")
-                                .text($errors[i][0] + ": " + $errors[i][1][0])
-                               ); 
+            'success', {
+              title: 'Success', 
+              htmlMessage: event.data.html_content
             }
-            // xx
-            $msg = $errorList.prop('outerHTML');
-          } else if ($status_code === 403) {
-            $msg = "Your request failed because the token sent with "
-                   + "your request is invalid. "
-          } else if ($status_code === 404) {
-            $msg = "That project was not found. "; 
-          } else if ($status_code === 503) {
-            $msg = event.data.errors + " ";
+          ); 
+          $('.launcher-form--container').addClass('is-hidden');
+        } else if (event.data.status === 'deploymentError') {
+          $('.launcher-form--container').addClass('is-hidden');
+
+          var status_code = event.data.status_code,
+              title = 'Error',
+              errorMessage = "There was an error in your request. Please contact " + 
+                             "the support team, or reload the page and try again.",
+              errors;
+
+          switch (status_code) {
+            case 400:
+            case 503:
+              errors = event.data.errors;
+              break;
+            case 403:
+              // These wonky structures are the way that we match DRF's errors.
+              errors = [
+                [
+                  '', 
+                  [['Your request failed because the token you sent with the request is invalid.']]
+                ]
+              ];
+              break;
+            case 404:
+              errors = [
+                [
+                  '', 
+                  [['That project was not found.']]
+                ]
+              ];
           }
 
           _show_notification(
-            'error', 'Error', 
-            "An error occured in your request: " + $msg + "Please contact the administrator."
-          )
+            'error', { 
+              title: title, 
+              textMessage: errorMessage, 
+              errors: errors 
+            }
+          );
 
         }
       }, false);


### PR DESCRIPTION
*Note: This includes the reloading commit, which is not on develop yet and will be handled in [another PR](https://github.com/appsembler/xblock-launchcontainer/pull/12/files).*

<img width="618" alt="launcherrequesterrorlist" src="https://user-images.githubusercontent.com/1884902/27809669-ab15d81c-6006-11e7-9813-680de325e03f.png">
<img width="540" alt="launcherrequestsuccess" src="https://user-images.githubusercontent.com/1884902/27809672-ab1e6d88-6006-11e7-9049-173a61ba9ca9.png">
<img width="911" alt="launcherrequesterror" src="https://user-images.githubusercontent.com/1884902/27809671-ab180164-6006-11e7-91c0-28d5fe674be1.png">
<img width="897" alt="launcherrequestpending" src="https://user-images.githubusercontent.com/1884902/27809670-ab1615f2-6006-11e7-84df-fcc0caac35ec.png">


https://trello.com/c/gsTtWI9c/1135-2-make-the-error-messages-better-upon-a-400