### PR TITLE
Get the user's email with django-crum

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,10 @@
 
 Open edX XBlock to launch containers from Appsembler's Virtual Labs (Wharf).
 
+# Requirements 
+
+This needs to run in one of two environments: the `xblock-sdk` or within Open edX. It has been tested with Dogwood, Eucalyptus, and Fikus. The only library required (besides, of course `xblock` is `django-crum`. I suspect your instance of Open edX already has both of these installed.
+
 # Installation
 
 ## FOR LOCAL DEVELOPMENT w/ xblock-sdk

--- a/launchcontainer/launchcontainer.py
+++ b/launchcontainer/launchcontainer.py
@@ -14,6 +14,7 @@ from django.db.models.signals import post_save
 from django.template import Context, Template
 from django.core.exceptions import ImproperlyConfigured
 
+from crum import get_current_user
 from xblock.core import XBlock
 from xblock.fields import Scope, String
 from xblock.fragment import Fragment
@@ -134,7 +135,7 @@ class LaunchContainerXBlock(XBlock):
             if get_current_site:
                 site = get_current_site()  # From the request.
             else:
-                site = Site.objects.all().order_by('domain').first()  # We're in the xblock-sdk.
+                site = Site.objects.all().order_by('domain').first()
 
         url = cache.get(make_cache_key(site.domain))
         if url:
@@ -196,12 +197,15 @@ class LaunchContainerXBlock(XBlock):
     @property
     def user_email(self):
 
-        user_email = None
+        user = get_current_user()
+        if hasattr(user, 'email'):
+            return user.email
+
         user_service = self.runtime.service(self, 'user')
         user = user_service.get_current_user()
-        user_email = user.emails[0] if type(user.emails) == list else user.email
+        email = user.emails[0] if type(user.emails) == list else user.email
 
-        return user_email
+        return email
 
     def student_view(self, context=None):
         """

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-launchcontainer',
-    version='2.1.1',
+    version='2.1.5',
     author='Bryan Wilson, Jazkarta',
     description=('Open EdX XBlock to display a button allowing an LMS user '
                  'to launch and link to an external courseware resource via the '
@@ -32,6 +32,7 @@ setup(
     ],
     install_requires=[
         'XBlock<0.5',
+        'django-crum'
     ],
     entry_points={
         'xblock.v1': [


### PR DESCRIPTION
Dogwood doesn't have the user service available,
but we really only need the email, so `django-crum`
does the trick!

FYI @bryanlandia. [This import](https://github.com/appsembler/edx-platform/blob/d8dbe5a07e42c361afbd5a13d86214bbefe66728/common/lib/xmodule/xmodule/modulestore/django.py#L42) fails on the `appsembler/feature/mergeDogwood.3` branch, so edx-platform acts like that service isn't available, though it is there (in one form or another). While I was in there, I found this `django-crum` module, which probably removes the need for any service anywho. 