### PR TITLE
Fix postmessage url origin check for IE

### DIFF
--- a/launchcontainer/static/js/src/launchcontainer.js
+++ b/launchcontainer/static/js/src/launchcontainer.js
@@ -1,9 +1,7 @@
 function getURLOrigin(path) {
   var link = document.createElement('a');
   link.setAttribute('href', path);
-
-  port = (link.port) ? ':'+link.port : '';
-  return link.protocol + '//' + link.hostname + port;
+  return link.protocol + '//' + link.host;
 }
 
 function objectifyForm(formArray) {//serialize data function

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-launchcontainer',
-    version='2.1.5',
+    version='2.1.7',
     author='Bryan Wilson, Appsembler',
     description=('Open EdX XBlock to display a button allowing an LMS user '
                  'to launch and link to an external courseware resource via the '


### PR DESCRIPTION
The issue with IE11 never returning the url was caused by `getURLOrigin` not returning a match to the even origin URL, since IE automatically adds a `port` attribute of `:443` to any https url, where  other browsers don't add the port.  Using `host` instead of `hostname` + `port` will be reliable across browsers, whether or not there is an explicit `:portnum` added to the tested url.

I used version 2.1.7 since I see (unreleased) 2.1.8 bumps the required XBlock version to 1.1.  We are using `0.4.14` on staging and prod due to compatibility with the video xblock.  edX Dogwood.3 uses 0.4, as well.
