### PR TITLE
automatically release to PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,13 @@ install:
 
 script:
   - python run_tests.py
+
+deploy:
+  provider: pypi
+  user: "appsembler"
+  password:
+    secure: "cvOpGzWDP0jZDvFqhPB0380/XU4FmkFL0275TAM+pFpX8Qj7CZjxqSKvxnKDh0HZfVBAa8vD/WQIB1N8eH5A8ZqjrGdNBSeZfFignjlZEXb3ELD5tliw61YMeyXxh1fhRBGsLDQ3ahnFxAC+EogXY3jZQgsKNuxLx25h3iH+9QZXxncGmgijIW8tKbs0PXGXKkJ6DkK5I5BEKqNe09Q6X533meyA2TsaNlZ5KHkUFOowCwXrxgKgDU6bQKL8kjU3DKjhGK1CuC0/DJAvP73f02ybv1bpoy79DCUzBVyRvT1L/TJMaWbgxMp/p+s8g1c3VS+Uenb7d4MFDQIzPfOVDWapiqbqIV7aOC1zYgpSJ+XeBBfNVX6B7HFZISIGBe7ICm2yvHlW5qOZNwX5j6AeqfLY2x6jknEzaRtyqtB9VyedyxFfSp+FyeO8/YvmCeVbIv+PSVSwSxS7v7lZxBuAEsqRQ3atU9E+ygwhkoIvAJkfTufJOm9G0Qk44kXNikDuUzNmzXYstGVQrdX+tT8xNkTbyNEbGAi5rpD3bpH4ZAcprKNZCv0WJ1egMdh4oUoz/A8aLMpGcVMEiOt6a7to3HxRGi5WPQuPV3RnPlz2u95NGnv0dhpra4AN1l+oq59dRSrCXQ6vmz2HNwPR0Jho9R3UwXmXKcDi4M7K9A+wNvk="
+  on:
+    tags: true
+  distributions: "sdist bdist_wheel"
+  skip_existing: true

--- a/docs/index.md
+++ b/docs/index.md
@@ -292,3 +292,10 @@ $ python -m unittest -v test_module
 To run the Python unit tests, you'll need the xblock-sdk. If you followed the steps above to install it, you should be able to run `python manage.py test` from the root of your xblock-sdk.
 
 [xblock-usage]: http://edx.readthedocs.io/projects/xblock-tutorial/en/latest/edx_platform/devstack.html
+
+# PyPI Release
+
+Creating a new release of the package and uploading it to PyPI is
+automated by TravisCI. It does expect certain conventions around
+branches and tags. Those are documnted in our internal wiki under the
+[Runbook: New PyPI Release](https://appsembler-infrastructure.appspot.com/post/runbook-new-pypi-release/) entry.


### PR DESCRIPTION
This configures TravisCI to automatically build and upload `sdist` and `bdist_wheel` packages to PyPI via our shared `appsembler` account.

Releases only go up when the change is pushed to the `master` branch (TravisCI default; you don't want random PRs to be able to trigger a release) with tags. The usual workflow for doing a release to PyPI then is to update the version in `setup.py`, etc. Merge it to `master`, tag a release locally (`git tag release-1.2.3`) then push that up with `git push --tags`.