### PR TITLE
Adds and catches extra error messages

### DIFF
--- a/launchcontainer/launchcontainer.py
+++ b/launchcontainer/launchcontainer.py
@@ -125,6 +125,13 @@ class LaunchContainerXBlock(XBlock):
         scope=Scope.content,
         help=(u"Enables students to reset/delete their container and start over")
     )
+    
+    support_email = String(
+        display_name='Tech support email',
+        default=u'',
+        scope=Scope.content,
+        help=(u"Email address of tech support for AVL labs."),
+    )
 
     @property
     def wharf_url(self, force=False):
@@ -229,6 +236,7 @@ class LaunchContainerXBlock(XBlock):
             'project': self.project,
             'project_friendly': self.project_friendly,
             'project_token': self.project_token,
+            'support_email': self.support_email,
             'user_email': self.user_email,
             'API_url': self.wharf_url,
             'API_delete_url': self.wharf_delete_url,
@@ -256,12 +264,14 @@ class LaunchContainerXBlock(XBlock):
                    (cls.project_friendly, 'string'),
                    (cls.project_token, 'string'),
                    (cls.enable_container_resetting, 'boolean'),
+                   (cls.support_email, 'string'),
                )
             )
 
             context = {'fields': edit_fields,
                        'API_url': self.wharf_url,
                        'API_delete_url': self.wharf_delete_url,
+                       'support_email': self.support_email,
                        'user_email': self.user_email
                        }
 
@@ -282,6 +292,7 @@ class LaunchContainerXBlock(XBlock):
             self.project = data['project'].strip()
             self.project_friendly = data['project_friendly'].strip()
             self.project_token = data['project_token'].strip()
+            self.support_email = data['support_email'].strip()
             self.api_url = self.wharf_url
             self.api_delete_url = self.wharf_delete_url
 

--- a/launchcontainer/static/css/launchcontainer.css
+++ b/launchcontainer/static/css/launchcontainer.css
@@ -26,3 +26,6 @@ div#launcher_notification p {
   padding: 10px;
 }
 
+#launcher_submit:disabled, #launcher_submit[disabled] {
+  color: rgba(0, 0, 0, 0.8);
+}

--- a/launchcontainer/static/js/src/launchcontainer.js
+++ b/launchcontainer/static/js/src/launchcontainer.js
@@ -145,7 +145,7 @@ function LaunchContainerXBlock(runtime, element) {
           var $final_msg = "<p class='error'>An error occurred with your request: " + $msg + "</p>"
                            + "<p> Please contact the administrator";
           if (supportEmail) {
-            $final_msg += ' at <a href="' + supportEmail + '">' + supportEmail + '</a>';
+            $final_msg += ' at <a href="' + supportEmail + '">' + supportEmail + '.</a>';
           }
           $final_msg += "</p>"
 

--- a/launchcontainer/static/js/src/launchcontainer.js
+++ b/launchcontainer/static/js/src/launchcontainer.js
@@ -59,7 +59,7 @@ function LaunchContainerXBlock(runtime, element) {
               '<br /><br />Lab taking a long time to load? Try contacting ' + 
               '<a href="mailto:' + supportEmail + '">' + supportEmail + '</a>'
             );
-          }, 150*1000); // show message after 2min 30s
+          }, 120*1000); // show message after 2min
         }
 
         // Shut down the buttons.

--- a/launchcontainer/static/js/src/launchcontainer.js
+++ b/launchcontainer/static/js/src/launchcontainer.js
@@ -124,10 +124,14 @@ function LaunchContainerXBlock(runtime, element) {
           clearTimeout(timeoutMessage);
           var $status_code = event.data.status_code;
           var $msg;
+          var errors = event.data.errors || event.data.detail || "";
           if ($status_code === 400) {
-            var $errors = event.data.errors;
-            for (i=0; i<$errors.length; i++) { 
-              $msg = $errors[i][0] + ": " + $errors[i][1][0] + " "; 
+            if (errors instanceof Array) {
+              for (i=0; i<errors.length; i++) { 
+                $msg = errors[i][0] + ": " + errors[i][1][0] + " "; 
+              }
+            } else {
+              $msg = errors + " ";
             }
           } else if ($status_code === 403) {
             $msg = "Your request failed because the token sent with "
@@ -135,15 +139,16 @@ function LaunchContainerXBlock(runtime, element) {
           } else if ($status_code === 404) {
             $msg = "That project was not found. "; 
           } else if ($status_code === 503) {
-            $msg = event.data.errors + " ";
+            $msg = errors + " ";
           }
           var supportEmail = "{{ support_email }}";
-          var $final_msg = "<p class='error'>An error occurred with your request: " + $msg + "</p>" 
+          var $final_msg = "<p class='error'>An error occurred with your request: " + $msg + "</p>"
                            + "<p> Please contact the administrator";
           if (supportEmail) {
             $final_msg += ' at <a href="' + supportEmail + '">' + supportEmail + '</a>';
           }
           $final_msg += "</p>"
+
           $launch_notification.html($final_msg);
           $launch_notification.addClass('ui-state-error').removeClass('hide');
         }

--- a/launchcontainer/static/js/src/launchcontainer_edit.js
+++ b/launchcontainer/static/js/src/launchcontainer_edit.js
@@ -7,7 +7,8 @@ function LaunchContainerEditBlock(runtime, element) {
           'enable_container_resetting': $('#enable_container_resetting_input').val(),
           'project': $('#project_input').val(),
           'project_friendly': $('#project_friendly_input').val(),
-          'project_token': $('#project_token_input').val()
+          'project_token': $('#project_token_input').val(),
+          'support_email': $('#support_email_input').val(),
         };
 
         $.post(handlerUrl, JSON.stringify(data))


### PR DESCRIPTION
This PR adds three things to the Launchcontainer XBlock:

- Editable support email field that gets preloaded with the value of `EDXAPP_TECH_SUPPORT_EMAIL` and is used when showing an error message
- An info message that appears  2mins after clicking on the container launcher and no container has launched yet. Since we don't know what the ping limit is on the backend, this is mostly handling the cases where containers have a really long startup time
- It handles more error messages from the backend, so that the user doesn't get the "undefined" error message, or worse, nothing at all.