### PR TITLE
Add default support email in xblock

### DIFF
--- a/launchcontainer/launchcontainer.py
+++ b/launchcontainer/launchcontainer.py
@@ -128,7 +128,7 @@ class LaunchContainerXBlock(XBlock):
 
     support_email = String(
         display_name='Tech support email',
-        default=getattr(settings, "TECH_SUPPORT_EMAIL", "")
+        default=getattr(settings, "TECH_SUPPORT_EMAIL", ""),
         scope=Scope.content,
         help=(u"Email address of tech support for AVL labs."),
     )

--- a/launchcontainer/launchcontainer.py
+++ b/launchcontainer/launchcontainer.py
@@ -125,10 +125,10 @@ class LaunchContainerXBlock(XBlock):
         scope=Scope.content,
         help=(u"Enables students to reset/delete their container and start over")
     )
-    
+
     support_email = String(
         display_name='Tech support email',
-        default=u'',
+        default=settings.EDXAPP_TECH_SUPPORT_EMAIL,
         scope=Scope.content,
         help=(u"Email address of tech support for AVL labs."),
     )

--- a/launchcontainer/launchcontainer.py
+++ b/launchcontainer/launchcontainer.py
@@ -128,7 +128,7 @@ class LaunchContainerXBlock(XBlock):
 
     support_email = String(
         display_name='Tech support email',
-        default=settings.EDXAPP_TECH_SUPPORT_EMAIL,
+        default=getattr(settings, "EDXAPP_TECH_SUPPORT_EMAIL", "")
         scope=Scope.content,
         help=(u"Email address of tech support for AVL labs."),
     )

--- a/launchcontainer/launchcontainer.py
+++ b/launchcontainer/launchcontainer.py
@@ -128,7 +128,7 @@ class LaunchContainerXBlock(XBlock):
 
     support_email = String(
         display_name='Tech support email',
-        default=getattr(settings, "EDXAPP_TECH_SUPPORT_EMAIL", "")
+        default=getattr(settings, "TECH_SUPPORT_EMAIL", "")
         scope=Scope.content,
         help=(u"Email address of tech support for AVL labs."),
     )

--- a/launchcontainer/tests.py
+++ b/launchcontainer/tests.py
@@ -31,7 +31,6 @@ class DummyResource(object):
     def __eq__(self, other):
         return isinstance(other, DummyResource) and self.path == other.path
 
-@override_settings(TECH_SUPPORT_EMAIL="support@appsembler.com")
 class LaunchContainerXBlockTests(unittest.TestCase):
     """
     Create a launchcontainer block with mock data.

--- a/launchcontainer/tests.py
+++ b/launchcontainer/tests.py
@@ -31,7 +31,7 @@ class DummyResource(object):
     def __eq__(self, other):
         return isinstance(other, DummyResource) and self.path == other.path
 
-@override_settings(EDXAPP_TECH_SUPPORT_EMAIL="support@appsembler.com")
+@override_settings(TECH_SUPPORT_EMAIL="support@appsembler.com")
 class LaunchContainerXBlockTests(unittest.TestCase):
     """
     Create a launchcontainer block with mock data.

--- a/launchcontainer/tests.py
+++ b/launchcontainer/tests.py
@@ -31,7 +31,7 @@ class DummyResource(object):
     def __eq__(self, other):
         return isinstance(other, DummyResource) and self.path == other.path
 
-
+@override_settings(EDXAPP_TECH_SUPPORT_EMAIL="support@appsembler.com")
 class LaunchContainerXBlockTests(unittest.TestCase):
     """
     Create a launchcontainer block with mock data.


### PR DESCRIPTION
Accidentally left this out in the last PR, it preloads the default support email in the XBlock from `settings.EDXAPP_TECH_SUPPORT_EMAIL`