### PR TITLE
move flake8 config to .flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 100

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,6 @@ deps = -r{toxinidir}/requirements/test.txt
 commands =
   python run_tests.py
 
-[flake8]
-max-line-length = 100
-
 [testenv:flake8]
 deps = flake8
 commands = flake8 launchcontainer *.py


### PR DESCRIPTION
per @briandant's request in #43.

`flake8` itself will look in `setup.cfg`, `tox.ini`, or `.flake8` for config. If it helps to put it in a particular place to support someone's editor, that's fine.