### PR TITLE
Juniper upgrade - Fix resource decoding to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed static files resource decoding as part of Python3 support
 
 ## [2.3.0] - 2020-11-17
 ### Added

--- a/launchcontainer/launchcontainer.py
+++ b/launchcontainer/launchcontainer.py
@@ -325,8 +325,7 @@ def load_resource(resource_path):  # pragma: NO COVER
     Gets the content of a resource
     """
     resource_content = pkg_resources.resource_string(__name__, resource_path)
-
-    return str(resource_content)  # noqa: F821
+    return resource_content.decode('utf-8')
 
 
 def render_template(template_path, context=None):  # pragma: NO COVER


### PR DESCRIPTION
Now loads resources by decoding with UTF-8 encoding

The problem was that the original code did `str(some_string)` which returned a byte encoded string causing the whole `xblocks.js` call chain to fail on a promise.


https://appsembler.atlassian.net/browse/RED-1946