### PR TITLE
update support from mailto to url

### DIFF
--- a/launchcontainer/launchcontainer.py
+++ b/launchcontainer/launchcontainer.py
@@ -134,7 +134,7 @@ class LaunchContainerXBlock(XBlock):
 
     support_email = String(
         display_name='Tech support email',
-        default=getattr(settings, "TECH_SUPPORT_EMAIL", ""),
+        default=None,
         scope=Scope.content,
         help=("Email address of tech support for AVL labs."),
     )
@@ -298,7 +298,7 @@ class LaunchContainerXBlock(XBlock):
             self.project = data['project'].strip()
             self.project_friendly = data['project_friendly'].strip()
             self.project_token = data['project_token'].strip()
-            self.support_email = data['support_email'].strip()
+            self.support_email = data.get('support_email', '').strip() or None
             self.api_url = self.wharf_url
             self.api_delete_url = self.wharf_delete_url
 

--- a/launchcontainer/static/js/src/launchcontainer.js
+++ b/launchcontainer/static/js/src/launchcontainer.js
@@ -52,6 +52,7 @@ function LaunchContainerXBlock(runtime, element) {
         $token = event.target.token.value;
 
         var supportEmail = "{{ support_email }}";
+        clearTimeout(timeoutMessage);
         timeoutMessage = setTimeout(function () { 
           var $support_link = '<a href="/help" rel="noreferrer" target="_blank">Contact us for support.</a>'; 
           if (supportEmail) {

--- a/launchcontainer/static/js/src/launchcontainer.js
+++ b/launchcontainer/static/js/src/launchcontainer.js
@@ -52,15 +52,15 @@ function LaunchContainerXBlock(runtime, element) {
         $token = event.target.token.value;
 
         var supportEmail = "{{ support_email }}";
-        clearTimeout(timeoutMessage);
-        if (supportEmail) {
-          timeoutMessage = setTimeout(function() {
-            $launch_notification.append(
-              '<br /><br />Lab taking a long time to load? Try contacting ' + 
-              '<a href="mailto:' + supportEmail + '">' + supportEmail + '</a>'
-            );
-          }, 120*1000); // show message after 2min
-        }
+        timeoutMessage = setTimeout(function () { 
+          var $support_link = '<a href="/help" rel="noreferrer" target="_blank">Contact us for support.</a>'; 
+          if (supportEmail) {
+            var $support_link = 'Try contacting <a href="mailto:' + supportEmail + '">' + supportEmail + '</a>'; 
+          } 
+          $launch_notification.append(
+            '<br /><br />Lab taking a long time to load? Try contacting ' + $support_link
+          ); 
+        }, 120 * 1000); // show message after 2min
 
         // Shut down the buttons.
         event.preventDefault();
@@ -146,6 +146,8 @@ function LaunchContainerXBlock(runtime, element) {
                            + "<p> Please contact the administrator";
           if (supportEmail) {
             $final_msg += ' at <a href="mailto:' + supportEmail + '">' + supportEmail + '.</a>';
+          } else {
+            $final_msg += 'at <a href="/help" rel="noreferrer" target="_blank">help section</a>';
           }
           $final_msg += "</p>"
 


### PR DESCRIPTION
## Change description

Update support for AVL issues to show URL (`tahoe-domain/help`)  instead of email `technical+{{ COMMON_DEPLOYMENT }}@appsembler.com` when `support_email` is not set.

Currently, our customer success team is providing T1 support for AVL issues from learners when the issues should be directed to the customer.   

Issue: https://appsembler.atlassian.net/browse/RED-2278

Linked to PRs in:

- ~~`configuration` - [PR-375](https://github.com/appsembler/configuration/pull/375)~~
-  ~~`edx-configs` - [PR-1144](https://github.com/appsembler/edx-configs/pull/1144)~~

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [RED-2278](https://appsembler.atlassian.net/browse/RED-2278) 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
