### PR TITLE
fix changelog links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Improved error handling for responses from AVL
 
-## [2.1.12] - 2019-04-09
+## 2.1.12 - 2019-04-09
 ### Added
 - Added a changelog
 ### Changed
@@ -43,10 +43,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 (sorry, we didn't keep a proper changelog previous to this release)
 
 [Unreleased]: https://github.com/appsembler/xblock-launchcontainer/compare/v2.3.2...HEAD
-[2.3.2]: https://github.com/appsembler/xblock-launchcontainer/compare/v2.3.2...HEAD
-[2.3.1]: https://github.com/appsembler/xblock-launchcontainer/compare/v2.3.1...v2.3.2
-[2.3.0]: https://github.com/appsembler/xblock-launchcontainer/compare/v2.3.0...v2.3.1
-[2.2.2]: https://github.com/appsembler/xblock-launchcontainer/compare/v2.2.2...v2.3.0
-[2.2.1]: https://github.com/appsembler/xblock-launchcontainer/compare/v2.2.1...v2.2.2
-[2.2.0]: https://github.com/appsembler/xblock-launchcontainer/compare/v2.2.0...v2.2.1
-[2.1.12]: https://github.com/appsembler/xblock-launchcontainer/compare/v2.1.12...v2.2.0
+[2.3.2]: https://github.com/appsembler/xblock-launchcontainer/compare/v2.3.1...v2.3.2
+[2.3.1]: https://github.com/appsembler/xblock-launchcontainer/compare/v2.3.0...v2.3.1
+[2.3.0]: https://github.com/appsembler/xblock-launchcontainer/compare/v2.2.2...v2.3.0
+[2.2.2]: https://github.com/appsembler/xblock-launchcontainer/compare/v2.2.1...v2.2.2
+[2.2.1]: https://github.com/appsembler/xblock-launchcontainer/compare/v2.2.0...v2.2.1
+[2.2.0]: https://github.com/appsembler/xblock-launchcontainer/compare/v2.1.12...v2.2.0


### PR DESCRIPTION
Somehow they had gotten inconsistent. Each version link should show the diff between that version and it's previous version, not the following version.
