### PR TITLE
fix tox django version specifier

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skipsdist = True
 
 [testenv]
 deps =
-    django22: Django<3
+    django2: Django<3
     -r{toxinidir}/requirements/test.txt
 
 commands =


### PR DESCRIPTION
It's actually using `django2` in the envs, not `django22`. So the Django restriction isn't being enforced and it was trying to install Django4.