### PR TITLE
Support Tahoe 2.0 site configuration client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
- - Install `tahoe-sites` and `site-configuration-client` to simulate Tahoe environment
- - Refactor testing environments to allow for more environments
+
+## [4.0.0] - 2022-09-19
+### Added
+
+ - Install `tahoe-sites` and `site-configuration-client` to simulate Tahoe environment.
+ - Add support for Tahoe 2.0 site by reading `LAUNCHCONTAINER_WHARF_URL` from Site Config Service `secret`s. Tahoe 1.0 sites will still use `site_values` as usual
+- Breaking change: Drop support for pre-Juniper Tahoe installations. The last version to support Hawthorn is `3.0.0`
+need to complicate the XBlock with caching calls.
+
+### Fixed
+ - Simplify reading the Wharf URL
+   * Read from `ENV_TOKENS` for regular Open edX installation (non-Tahoe)
+   * Read from [Site Configuration Client](https://github.com/appsembler/site-configuration-client/) for Juniper+ installations
+
+### Changed
+ - Refactored unit tests
+ - Refactor testing environments in `tox.ini` to test for `tahoe` and non `tahoe` environments removing `tox-gh-actions`.
+ - Remove complex and low-value caching for `wharf_url`
 
 ## [3.0.0] - 2021-09-03
 

--- a/launchcontainer/static/html/launchcontainer.html
+++ b/launchcontainer/static/html/launchcontainer.html
@@ -1,4 +1,5 @@
 <div id="launcher1">
+{% if API_url %}
   <iframe src="{{ API_url }}" style="visibility: hidden" width="0" height="0"></iframe>
   <form id="launcher_form">
     <input type="text" class="hide" id="launcher_email" name="owner_email" {% if user_email %}value="{{ user_email }}"{% endif %} placeholder="Please enter your email address" />
@@ -8,5 +9,10 @@
   </form>
   <div id="launcher_notification" class="hide"></div>
   {% if enable_container_resetting %}<button type="button" class="ui-priority-primary" id="launcher_reset">Reset lab</button>{% endif %}
-
+{% else %}
+  {# This message is intended to appear Studio for course authors. #}
+  <p><strong>Error: Unable to connect to the Appsembler Virtual Labs API endpoint.</strong></p>
+  <p>Please configure your Appsembler Virtual Labs API endpoint before using this XBlock.</p>
+  <p>Contact the <a href="mailto:support@appsembler.com" target="_blank">Appsembler Support</a> for assistance.</p>
+{% endif %}
 </div>

--- a/launchcontainer/test_settings.py
+++ b/launchcontainer/test_settings.py
@@ -1,0 +1,25 @@
+"""
+Test settings for the Launchcontainer XBlock.
+"""
+
+from workbench.settings import *  # noqa - needed for the XBlock tests to work
+from workbench.settings import INSTALLED_APPS
+
+from django.conf.global_settings import LOGGING  # noqa - fix workbench-specific log requirements
+
+
+INSTALLED_APPS += [
+    'django.contrib.sites',
+    'launchcontainer',
+]
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+    }
+}
+
+ENV_TOKENS = {
+    'LAUNCHCONTAINER_WHARF_URL': 'dummy',
+}

--- a/requirements/tahoe.txt
+++ b/requirements/tahoe.txt
@@ -8,5 +8,5 @@
 #  - Communicate with the team to ensure no breaking changes are introduced.
 #
 
-tahoe-sites==1.3.1  # Juniper-compatible
-site-configuration-client==0.2.2  # Juniper-compatible
+tahoe-sites==1.3.2  # Juniper-compatible
+site-configuration-client==0.2.3  # Juniper-compatible

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,7 +6,6 @@
 #  - Communicate with the team to ensure no breaking changes are introduced.
 #
 
-mock==2.0.0
 edx-opaque-keys==0.4.4
 django-crum==0.7.3
 selenium==3.4.3
@@ -26,3 +25,7 @@ XBlock>=1.4.0; python_version >= '3.9'  # Koa+
 
 xblock-sdk==0.2.2; python_version < '3.9'  # Juniper
 xblock-sdk>=0.3.0; python_version >= '3.9'  # Koa+
+
+django-pyfs==2.2
+lazy==1.4
+mock==2.0.0

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,32 +1,12 @@
 import django
-from django.conf import settings
+import os
 from django.core.management import call_command
 
 
 def main():
     # Dynamically configure the Django settings with the minimum necessary to
     # get Django running tests
-    settings.configure(
-        INSTALLED_APPS=(
-            'django.contrib.sites',
-            'launchcontainer',
-        ),
-        # Django replaces this, but it still wants it. *shrugs*
-        DATABASES={
-            'default': {
-                'ENGINE': 'django.db.backends.sqlite3',
-                'NAME': ':memory:',
-                'HOST': '',
-                'PORT': '',
-                'USER': '',
-                'PASSWORD': '',
-            }
-        },
-        ENV_TOKENS={
-            'LAUNCHCONTAINER_WHARF_URL': 'dummy',
-        },
-    )
-
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'launchcontainer.test_settings')
     django.setup()
 
     # Fire off the tests

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-launchcontainer',
-    version='3.0.0',
+    version='4.0.0',
     author='Bryan Wilson, Appsembler',
     description=('Open EdX XBlock to display a button allowing an LMS user '
                  'to launch and link to an external courseware resource via the '


### PR DESCRIPTION
Fix [RED-3385](https://appsembler.atlassian.net/browse/RED-3385). Read Tahoe 2 site from `secret` on Tahoe 2.0 sites and from `site_values` on Tahoe 1.0 sites.

### Breaking change
Tahoe Hawthorn is no longer supported in v4.0.0 due to the lack of [Site Configuration Client](https://github.com/appsembler/site-configuration-client/). It will act as if it's installed on a Vanilla Hawthorn.

### TODO
 - [x] Test on devstack with site configuration on a Tahoe 2.0 site
   - [x] with site-specific value
   - [x] with `ENV_TOKENS` value
 - [x] Test on devstack with site configuration on a Tahoe 1.0 site
   - [x] with site-specific value
   - [x] with `ENV_TOKENS` value
